### PR TITLE
Allow namespace column to have its visibility toggled

### DIFF
--- a/plugins/kubernetes/ui/src/components/kubernetes/table/shared/columns/namespaceColumn.tsx
+++ b/plugins/kubernetes/ui/src/components/kubernetes/table/shared/columns/namespaceColumn.tsx
@@ -6,7 +6,7 @@ export const namespaceColumn = <T extends { metadata?: { namespace?: string } }>
   header: 'Namespace',
   accessorKey: 'metadata.namespace',
   enableSorting: true,
-  enableHiding: false,
+  enableHiding: true,
   filterFn: namespaceFilter,
   size: 150,
 })


### PR DESCRIPTION
As of now, you can’t turn off the namespace column in any resource, which would be useful if you’ve already limited results to a specific namespace, meaning you know that all resources in the table will be in the same namespace, and you want the additional column real-estate back.

This PR enables that.