### PR TITLE
fix: parse ANSI escape sequences in log viewer to render colored logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ dist-ssr
 
 
 .nx
+
+# Benchmark output
+benchmarks/

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "postinstall": "pnpm run bundle:yaml-worker",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "nx preview",
-    "test": "jest"
+    "test": "jest",
+    "bench": "vitest bench --config vitest.bench.config.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -58,7 +58,8 @@
     "dist",
     "build",
     "**/*.spec.ts",
-    "**/*.spec.tsx"
+    "**/*.spec.tsx",
+    "**/*.bench.ts"
   ],
   "include": [
     "ui",

--- a/ui/providers/BottomDrawer/containers/LogViewer/LogEntry.spec.tsx
+++ b/ui/providers/BottomDrawer/containers/LogViewer/LogEntry.spec.tsx
@@ -25,6 +25,7 @@ const defaultProps = {
   showSources: false,
   showLineNumbers: false,
   wrap: false,
+  colorize: true,
 };
 
 /** jsdom normalises hex colors to rgb() — match either form. */

--- a/ui/providers/BottomDrawer/containers/LogViewer/LogEntry.tsx
+++ b/ui/providers/BottomDrawer/containers/LogViewer/LogEntry.tsx
@@ -10,6 +10,7 @@ interface Props {
   showSources: boolean;
   showLineNumbers: boolean;
   wrap: boolean;
+  colorize: boolean;
   searchMatches?: SearchMatch[];
   /** startOffset of the current match on this line, or -1 if current match is on another line */
   currentMatchOffset?: number;
@@ -208,6 +209,7 @@ const LogEntryComponent: React.FC<Props> = ({
   showSources,
   showLineNumbers,
   wrap,
+  colorize,
   searchMatches,
   currentMatchOffset = -1,
 }) => {
@@ -222,7 +224,7 @@ const LogEntryComponent: React.FC<Props> = ({
   }, []);
 
   const renderContent = () => {
-    const segments = entry.ansiSegments;
+    const segments = colorize ? entry.ansiSegments : undefined;
     const hasSearch = searchMatches && searchMatches.length > 0;
 
     // Fast path: no ANSI, no search → plain text.
@@ -342,6 +344,7 @@ export default React.memo(LogEntryComponent, (prev, next) => {
     prev.showSources === next.showSources &&
     prev.showLineNumbers === next.showLineNumbers &&
     prev.wrap === next.wrap &&
+    prev.colorize === next.colorize &&
     prev.searchMatches === next.searchMatches &&
     prev.currentMatchOffset === next.currentMatchOffset
   );

--- a/ui/providers/BottomDrawer/containers/LogViewer/LogEntry.tsx
+++ b/ui/providers/BottomDrawer/containers/LogViewer/LogEntry.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Box from '@mui/material/Box';
 import { Text } from '@omniviewdev/ui/typography';
-import type { LogEntry as LogEntryType, SearchMatch } from './types';
+import type { AnsiSegment, LogEntry as LogEntryType, SearchMatch } from './types';
 import { LEVEL_COLORS } from './types';
 
 interface Props {
@@ -57,6 +57,151 @@ function formatTimestamp(ts: string): string {
   }
 }
 
+/** Build a CSS style object for an ANSI segment. */
+function ansiStyle(seg: AnsiSegment): React.CSSProperties | undefined {
+  if (!seg.fg && !seg.bg && !seg.bold && !seg.dim && !seg.italic && !seg.underline && !seg.strikethrough) {
+    return undefined;
+  }
+  const s: React.CSSProperties = {};
+  if (seg.fg) s.color = seg.fg;
+  if (seg.bg) s.backgroundColor = seg.bg;
+  if (seg.bold) s.fontWeight = 'bold';
+  if (seg.dim) s.opacity = 0.7;
+  if (seg.italic) s.fontStyle = 'italic';
+  const deco: string[] = [];
+  if (seg.underline) deco.push('underline');
+  if (seg.strikethrough) deco.push('line-through');
+  if (deco.length > 0) s.textDecoration = deco.join(' ');
+  return s;
+}
+
+/** Render ANSI segments as styled spans (no search). */
+function renderAnsiSegments(segments: AnsiSegment[]): React.ReactNode[] {
+  return segments.map((seg, i) => {
+    const style = ansiStyle(seg);
+    return style ? <span key={i} style={style}>{seg.text}</span> : seg.text;
+  });
+}
+
+/** Render plain text with search highlights (no ANSI). */
+function renderSearchHighlights(
+  content: string,
+  matches: SearchMatch[],
+  currentMatchOffset: number,
+  scrollToMatchRef: (node: HTMLSpanElement | null) => void,
+): React.ReactNode[] {
+  const parts: React.ReactNode[] = [];
+  let lastIndex = 0;
+  for (const match of matches) {
+    if (match.startOffset > lastIndex) {
+      parts.push(content.slice(lastIndex, match.startOffset));
+    }
+    const isCurrent = match.startOffset === currentMatchOffset;
+    parts.push(
+      <span
+        key={match.startOffset}
+        ref={isCurrent ? scrollToMatchRef : undefined}
+        style={{
+          backgroundColor: isCurrent ? '#ff9800' : '#ffeb3b',
+          color: '#000',
+          borderRadius: 2,
+        }}
+      >
+        {content.slice(match.startOffset, match.endOffset)}
+      </span>,
+    );
+    lastIndex = match.endOffset;
+  }
+  if (lastIndex < content.length) {
+    parts.push(content.slice(lastIndex));
+  }
+  return parts;
+}
+
+/**
+ * Render ANSI segments with search highlight overlay.
+ *
+ * Search match offsets are relative to the stripped plain text. We walk through
+ * segments (whose concatenated .text equals the plain text) and split them at
+ * highlight boundaries, layering highlight styles on top of ANSI styles.
+ */
+function renderAnsiWithSearch(
+  segments: AnsiSegment[],
+  matches: SearchMatch[],
+  currentMatchOffset: number,
+  scrollToMatchRef: (node: HTMLSpanElement | null) => void,
+): React.ReactNode[] {
+  const parts: React.ReactNode[] = [];
+  let matchIdx = 0;
+  let globalOffset = 0; // current position in the plain text
+  let key = 0;
+
+  for (const seg of segments) {
+    const baseStyle = ansiStyle(seg);
+    let segPos = 0; // position within this segment's text
+
+    while (segPos < seg.text.length) {
+      // If no more matches, emit the rest of this segment with its ANSI style.
+      if (matchIdx >= matches.length) {
+        const text = seg.text.substring(segPos);
+        parts.push(baseStyle ? <span key={key++} style={baseStyle}>{text}</span> : text);
+        segPos = seg.text.length;
+        break;
+      }
+
+      const match = matches[matchIdx];
+      const matchStart = match.startOffset;
+      const matchEnd = match.endOffset;
+      const absPos = globalOffset + segPos;
+
+      // Before the next match: emit un-highlighted text.
+      if (absPos < matchStart) {
+        const take = Math.min(matchStart - absPos, seg.text.length - segPos);
+        const text = seg.text.substring(segPos, segPos + take);
+        parts.push(baseStyle ? <span key={key++} style={baseStyle}>{text}</span> : text);
+        segPos += take;
+        continue;
+      }
+
+      // Inside a match: emit highlighted text.
+      if (absPos < matchEnd) {
+        const take = Math.min(matchEnd - absPos, seg.text.length - segPos);
+        const text = seg.text.substring(segPos, segPos + take);
+        const isCurrent = match.startOffset === currentMatchOffset;
+        const hlStyle: React.CSSProperties = {
+          ...baseStyle,
+          backgroundColor: isCurrent ? '#ff9800' : '#ffeb3b',
+          color: '#000',
+          borderRadius: 2,
+        };
+        parts.push(
+          <span
+            key={key++}
+            ref={isCurrent && absPos === matchStart ? scrollToMatchRef : undefined}
+            style={hlStyle}
+          >
+            {text}
+          </span>,
+        );
+        segPos += take;
+
+        // If we've reached the end of this match, advance to the next.
+        if (globalOffset + segPos >= matchEnd) {
+          matchIdx++;
+        }
+        continue;
+      }
+
+      // Past this match (shouldn't normally happen, but be safe).
+      matchIdx++;
+    }
+
+    globalOffset += seg.text.length;
+  }
+
+  return parts;
+}
+
 const LogEntryComponent: React.FC<Props> = ({
   entry,
   showTimestamps,
@@ -77,40 +222,26 @@ const LogEntryComponent: React.FC<Props> = ({
   }, []);
 
   const renderContent = () => {
-    if (!searchMatches || searchMatches.length === 0) {
+    const segments = entry.ansiSegments;
+    const hasSearch = searchMatches && searchMatches.length > 0;
+
+    // Fast path: no ANSI, no search → plain text.
+    if (!segments && !hasSearch) {
       return entry.content;
     }
 
-    // Highlight search matches — only the current match gets orange
-    const parts: React.ReactNode[] = [];
-    let lastIndex = 0;
-
-    for (const match of searchMatches) {
-      if (match.startOffset > lastIndex) {
-        parts.push(entry.content.slice(lastIndex, match.startOffset));
-      }
-      const isCurrent = match.startOffset === currentMatchOffset;
-      parts.push(
-        <span
-          key={match.startOffset}
-          ref={isCurrent ? scrollToMatchRef : undefined}
-          style={{
-            backgroundColor: isCurrent ? '#ff9800' : '#ffeb3b',
-            color: '#000',
-            borderRadius: 2,
-          }}
-        >
-          {entry.content.slice(match.startOffset, match.endOffset)}
-        </span>,
-      );
-      lastIndex = match.endOffset;
+    // No ANSI segments → plain text with search highlights (original path).
+    if (!segments && hasSearch) {
+      return renderSearchHighlights(entry.content, searchMatches!, currentMatchOffset, scrollToMatchRef);
     }
 
-    if (lastIndex < entry.content.length) {
-      parts.push(entry.content.slice(lastIndex));
+    // ANSI segments present, no search → styled spans.
+    if (segments && !hasSearch) {
+      return renderAnsiSegments(segments);
     }
 
-    return parts;
+    // Both ANSI segments and search → overlay highlights onto styled segments.
+    return renderAnsiWithSearch(segments!, searchMatches!, currentMatchOffset, scrollToMatchRef);
   };
 
   return (

--- a/ui/providers/BottomDrawer/containers/LogViewer/LogEntry.tsx
+++ b/ui/providers/BottomDrawer/containers/LogViewer/LogEntry.tsx
@@ -339,7 +339,7 @@ const LogEntryComponent: React.FC<Props> = ({
 
 export default React.memo(LogEntryComponent, (prev, next) => {
   return (
-    prev.entry.lineNumber === next.entry.lineNumber &&
+    prev.entry === next.entry &&
     prev.showTimestamps === next.showTimestamps &&
     prev.showSources === next.showSources &&
     prev.showLineNumbers === next.showLineNumbers &&

--- a/ui/providers/BottomDrawer/containers/LogViewer/LogViewerToolbar.tsx
+++ b/ui/providers/BottomDrawer/containers/LogViewer/LogViewerToolbar.tsx
@@ -20,6 +20,7 @@ import {
   LuTrash2,
   LuPause,
   LuPlay,
+  LuPalette,
   LuX,
 } from 'react-icons/lu';
 
@@ -67,6 +68,8 @@ interface Props {
   onToggleLineNumbers: () => void;
   wrap: boolean;
   onToggleWrap: () => void;
+  colorize: boolean;
+  onToggleColorize: () => void;
   follow: boolean;
   onToggleFollow: () => void;
   paused: boolean;
@@ -103,6 +106,8 @@ const LogViewerToolbar: React.FC<Props> = ({
   onToggleLineNumbers,
   wrap,
   onToggleWrap,
+  colorize,
+  onToggleColorize,
   follow,
   onToggleFollow,
   paused,
@@ -251,6 +256,17 @@ const LogViewerToolbar: React.FC<Props> = ({
           onClick={onToggleWrap}
         >
           <LuWrapText size={14} />
+        </IconButton>
+      </Tooltip>
+
+      <Tooltip content={colorize ? 'ANSI colors on' : 'ANSI colors off'}>
+        <IconButton
+          size="sm"
+          emphasis={colorize ? 'soft' : 'ghost'}
+          color={colorize ? 'primary' : 'neutral'}
+          onClick={onToggleColorize}
+        >
+          <LuPalette size={14} />
         </IconButton>
       </Tooltip>
 

--- a/ui/providers/BottomDrawer/containers/LogViewer/index.tsx
+++ b/ui/providers/BottomDrawer/containers/LogViewer/index.tsx
@@ -29,6 +29,7 @@ const LogViewerContainer: React.FC<Props> = ({ sessionId }) => {
   const [showSources, setShowSources] = useState(true);
   const [showLineNumbers, setShowLineNumbers] = useState(false);
   const [wrap, setWrap] = useState(false);
+  const [colorize, setColorize] = useState(true);
   const [follow, setFollow] = useState(true);
   const [paused, setPaused] = useState(false);
   const [events, setEvents] = useState<LogStreamEvent[]>([]);
@@ -192,6 +193,8 @@ const LogViewerContainer: React.FC<Props> = ({ sessionId }) => {
         onToggleLineNumbers={() => setShowLineNumbers(!showLineNumbers)}
         wrap={wrap}
         onToggleWrap={() => setWrap(!wrap)}
+        colorize={colorize}
+        onToggleColorize={() => setColorize(!colorize)}
         follow={follow}
         onToggleFollow={() => setFollow(!follow)}
         paused={paused}
@@ -337,6 +340,7 @@ const LogViewerContainer: React.FC<Props> = ({ sessionId }) => {
                     showSources={showSources}
                     showLineNumbers={showLineNumbers}
                     wrap={wrap}
+                    colorize={colorize}
                     searchMatches={matchesByLine.get(virtualRow.index)}
                     currentMatchOffset={virtualRow.index === currentMatchLine ? currentMatchOffset : -1}
                   />

--- a/ui/providers/BottomDrawer/containers/LogViewer/types.ts
+++ b/ui/providers/BottomDrawer/containers/LogViewer/types.ts
@@ -1,13 +1,27 @@
+export interface AnsiSegment {
+  text: string;
+  fg?: string;
+  bg?: string;
+  bold?: boolean;
+  dim?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  strikethrough?: boolean;
+}
+
 export interface LogEntry {
   lineNumber: number;
   sessionId: string;
   sourceId: string;
   labels: Record<string, string>;
   timestamp: string;
+  /** Plain text content with ANSI codes stripped (used by search, level detection, download). */
   content: string;
   origin: 'CURRENT' | 'PREVIOUS' | 'SYSTEM';
   level?: 'error' | 'warn' | 'info' | 'debug' | 'trace';
   isJson?: boolean;
+  /** Styled segments for ANSI color rendering. Empty when no ANSI codes were present. */
+  ansiSegments?: AnsiSegment[];
 }
 
 export interface LogSource {

--- a/ui/providers/BottomDrawer/containers/LogViewer/utils/parseAnsi.bench.ts
+++ b/ui/providers/BottomDrawer/containers/LogViewer/utils/parseAnsi.bench.ts
@@ -1,0 +1,128 @@
+import { bench, describe } from 'vitest';
+import { parseAnsi } from './parseAnsi';
+
+// ---------------------------------------------------------------------------
+// Test data — representative of real Kubernetes / application log lines
+// ---------------------------------------------------------------------------
+
+const PLAIN_SHORT = '2024-01-15T10:30:00Z INFO server started on :8080';
+const PLAIN_LONG = `2024-01-15T10:30:00.123456Z INFO  [request_id=abc-123-def-456] GET /api/v1/namespaces/kube-system/pods?labelSelector=app%3Dcoredns&limit=500 responded 200 in 12.34ms (bytes_in=0, bytes_out=48291, user_agent="kubectl/v1.28.0")`;
+
+// Typical Go structured logger (zap/zerolog) — 4 SGR pairs
+const COLORED_TYPICAL = '\x1b[90m2024-01-15T10:30:00Z\x1b[0m \x1b[1;31mERROR\x1b[0m \x1b[36mmain.go:42\x1b[0m Failed to connect to \x1b[33mdatabase\x1b[0m service';
+
+// Heavy — 24-bit color, 256-color, multiple attributes
+const COLORED_HEAVY = '\x1b[1m\x1b[38;2;255;128;0m2024-01-15\x1b[0m \x1b[48;5;196m\x1b[38;5;231mERROR\x1b[0m \x1b[3m\x1b[4m\x1b[38;2;100;200;50mcontroller.go:127\x1b[0m \x1b[2mFailed to reconcile \x1b[1;33mDeployment\x1b[0m/\x1b[36mnginx-ingress\x1b[0m in namespace \x1b[35mkube-system\x1b[0m: \x1b[91mconnection refused\x1b[0m';
+
+// Python traceback — multi-line, many color changes
+const PYTHON_TRACEBACK = [
+  '\x1b[1;31mTraceback (most recent call last):\x1b[0m',
+  '  File \x1b[36m"/app/main.py"\x1b[0m, line \x1b[33m42\x1b[0m, in \x1b[32mhandle_request\x1b[0m',
+  '    result = \x1b[35mprocess\x1b[0m(\x1b[33mdata\x1b[0m)',
+  '  File \x1b[36m"/app/processor.py"\x1b[0m, line \x1b[33m108\x1b[0m, in \x1b[32mprocess\x1b[0m',
+  '    raise \x1b[1;31mValueError\x1b[0m(\x1b[33m"invalid input"\x1b[0m)',
+  '\x1b[1;31mValueError\x1b[0m: \x1b[33minvalid input\x1b[0m',
+].join('\n');
+
+// Pathological — 50 rapid color changes in a single line
+let PATHOLOGICAL = '';
+for (let i = 0; i < 50; i++) {
+  PATHOLOGICAL += `\x1b[${30 + (i % 8)};${i % 2 ? 1 : 2}mword${i} `;
+}
+PATHOLOGICAL += '\x1b[0m';
+
+// OSC hyperlink sequences (some terminal loggers emit these)
+const OSC_LINKS = '\x1b]8;;https://github.com/org/repo/blob/main/pkg/ctrl/ctrl.go#L42\x1b\\ctrl.go:42\x1b]8;;\x1b\\ \x1b[31mERROR\x1b[0m connection timeout';
+
+// Batches — simulate real ingest patterns
+const BATCH_MIXED_100 = Array.from({ length: 100 }, (_, i) => {
+  switch (i % 5) {
+    case 0: return COLORED_TYPICAL;
+    case 1: return PLAIN_LONG;
+    case 2: return COLORED_HEAVY;
+    case 3: return PLAIN_SHORT;
+    default: return PYTHON_TRACEBACK;
+  }
+});
+
+const BATCH_PLAIN_100 = Array.from({ length: 100 }, () => PLAIN_LONG);
+const BATCH_COLORED_100 = Array.from({ length: 100 }, (_, i) =>
+  i % 2 === 0 ? COLORED_TYPICAL : COLORED_HEAVY
+);
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+describe('parseAnsi', () => {
+  describe('single line', () => {
+    bench('plain short (fast path — indexOf bail)', () => {
+      parseAnsi(PLAIN_SHORT);
+    });
+
+    bench('plain long (fast path)', () => {
+      parseAnsi(PLAIN_LONG);
+    });
+
+    bench('colored typical (4 SGR pairs, Go logger)', () => {
+      parseAnsi(COLORED_TYPICAL);
+    });
+
+    bench('colored heavy (256-color, RGB, attrs)', () => {
+      parseAnsi(COLORED_HEAVY);
+    });
+
+    bench('python traceback (multi-line, many SGR)', () => {
+      parseAnsi(PYTHON_TRACEBACK);
+    });
+
+    bench('pathological (50 rapid color changes)', () => {
+      parseAnsi(PATHOLOGICAL);
+    });
+
+    bench('OSC hyperlinks + SGR', () => {
+      parseAnsi(OSC_LINKS);
+    });
+  });
+
+  describe('batch ingest (100 lines)', () => {
+    bench('100 mixed lines (plain + colored)', () => {
+      for (let i = 0; i < BATCH_MIXED_100.length; i++) {
+        parseAnsi(BATCH_MIXED_100[i]);
+      }
+    });
+
+    bench('100 plain lines (all fast path)', () => {
+      for (let i = 0; i < BATCH_PLAIN_100.length; i++) {
+        parseAnsi(BATCH_PLAIN_100[i]);
+      }
+    });
+
+    bench('100 colored lines (worst case)', () => {
+      for (let i = 0; i < BATCH_COLORED_100.length; i++) {
+        parseAnsi(BATCH_COLORED_100[i]);
+      }
+    });
+  });
+
+  describe('buffer fill (100k lines — full log buffer)', () => {
+    // This simulates filling the entire 100k circular buffer.
+    // Target: under 500ms for the full buffer on modern hardware.
+    bench('100k plain lines', () => {
+      for (let i = 0; i < 1000; i++) {
+        // Inner loop of 100 to reach 100k total
+        for (let j = 0; j < BATCH_PLAIN_100.length; j++) {
+          parseAnsi(BATCH_PLAIN_100[j]);
+        }
+      }
+    }, { iterations: 3, warmupIterations: 1 });
+
+    bench('100k mixed lines', () => {
+      for (let i = 0; i < 1000; i++) {
+        for (let j = 0; j < BATCH_MIXED_100.length; j++) {
+          parseAnsi(BATCH_MIXED_100[j]);
+        }
+      }
+    }, { iterations: 3, warmupIterations: 1 });
+  });
+});

--- a/ui/providers/BottomDrawer/containers/LogViewer/utils/parseAnsi.spec.ts
+++ b/ui/providers/BottomDrawer/containers/LogViewer/utils/parseAnsi.spec.ts
@@ -1,0 +1,334 @@
+import { parseAnsi } from './parseAnsi';
+import type { ParsedAnsi } from './parseAnsi';
+
+/** Helper: extract just text from segments for easier assertions. */
+function texts(result: ParsedAnsi): string[] {
+  return result.segments.map(s => s.text);
+}
+
+/** Helper: extract fg colors from segments. */
+function fgs(result: ParsedAnsi): (string | undefined)[] {
+  return result.segments.map(s => s.fg);
+}
+
+describe('parseAnsi', () => {
+  // ---- Fast path: no ANSI ----
+
+  it('returns plain text as-is with no segments', () => {
+    const result = parseAnsi('hello world');
+    expect(result.plain).toBe('hello world');
+    expect(result.segments).toEqual([]);
+    expect(result.hasAnsi).toBe(false);
+  });
+
+  it('returns empty string with no segments', () => {
+    const result = parseAnsi('');
+    expect(result.plain).toBe('');
+    expect(result.segments).toEqual([]);
+    expect(result.hasAnsi).toBe(false);
+  });
+
+  // ---- Basic SGR ----
+
+  it('parses single color code', () => {
+    const result = parseAnsi('\x1b[31mERROR\x1b[0m');
+    expect(result.plain).toBe('ERROR');
+    expect(result.hasAnsi).toBe(true);
+    expect(result.segments).toHaveLength(1);
+    expect(result.segments[0].text).toBe('ERROR');
+    expect(result.segments[0].fg).toBe('#cc0000'); // red
+  });
+
+  it('parses color with trailing text after reset', () => {
+    const result = parseAnsi('\x1b[31mERROR\x1b[0m normal text');
+    expect(result.plain).toBe('ERROR normal text');
+    expect(result.segments).toHaveLength(2);
+    expect(result.segments[0]).toEqual({ text: 'ERROR', fg: '#cc0000' });
+    expect(result.segments[1]).toEqual({ text: ' normal text' });
+  });
+
+  it('parses text before, during, and after color', () => {
+    const result = parseAnsi('before \x1b[32mgreen\x1b[0m after');
+    expect(result.plain).toBe('before green after');
+    expect(texts(result)).toEqual(['before ', 'green', ' after']);
+    expect(fgs(result)).toEqual([undefined, '#4e9a06', undefined]);
+  });
+
+  // ---- Standard colors (30-37) ----
+
+  it.each([
+    [30, '#000000', 'black'],
+    [31, '#cc0000', 'red'],
+    [32, '#4e9a06', 'green'],
+    [33, '#c4a000', 'yellow'],
+    [34, '#3465a4', 'blue'],
+    [35, '#75507b', 'magenta'],
+    [36, '#06989a', 'cyan'],
+    [37, '#d3d7cf', 'white'],
+  ] as const)('maps SGR %i to %s (%s)', (code, expectedColor, _name) => {
+    const result = parseAnsi(`\x1b[${code}mtext\x1b[0m`);
+    expect(result.segments[0].fg).toBe(expectedColor);
+  });
+
+  // ---- Bright colors (90-97) ----
+
+  it.each([
+    [90, '#555753', 'bright black'],
+    [91, '#ef2929', 'bright red'],
+    [92, '#8ae234', 'bright green'],
+    [93, '#fce94f', 'bright yellow'],
+    [94, '#729fcf', 'bright blue'],
+    [95, '#ad7fa8', 'bright magenta'],
+    [96, '#34e2e2', 'bright cyan'],
+    [97, '#eeeeec', 'bright white'],
+  ] as const)('maps SGR %i to %s (%s)', (code, expectedColor, _name) => {
+    const result = parseAnsi(`\x1b[${code}mtext\x1b[0m`);
+    expect(result.segments[0].fg).toBe(expectedColor);
+  });
+
+  // ---- Background colors ----
+
+  it('parses standard background color', () => {
+    const result = parseAnsi('\x1b[41mtext\x1b[0m');
+    expect(result.segments[0].bg).toBe('#cc0000');
+  });
+
+  it('parses bright background color', () => {
+    const result = parseAnsi('\x1b[101mtext\x1b[0m');
+    expect(result.segments[0].bg).toBe('#ef2929');
+  });
+
+  // ---- 256-color mode ----
+
+  it('parses 256-color foreground (standard range 0-7)', () => {
+    const result = parseAnsi('\x1b[38;5;1mtext\x1b[0m');
+    expect(result.segments[0].fg).toBe('#cc0000');
+  });
+
+  it('parses 256-color foreground (bright range 8-15)', () => {
+    const result = parseAnsi('\x1b[38;5;9mtext\x1b[0m');
+    expect(result.segments[0].fg).toBe('#ef2929');
+  });
+
+  it('parses 256-color foreground (color cube 16-231)', () => {
+    const result = parseAnsi('\x1b[38;5;196mtext\x1b[0m');
+    // 196 = 16 + (5*36 + 0*6 + 0) = index 180 in cube → r=5,g=0,b=0 → #ff0000
+    expect(result.segments[0].fg).toBe('#ff0000');
+  });
+
+  it('parses 256-color foreground (grayscale 232-255)', () => {
+    const result = parseAnsi('\x1b[38;5;240mtext\x1b[0m');
+    // 240 - 232 = 8 → 8*10 + 8 = 88 → #585858
+    expect(result.segments[0].fg).toBe('#585858');
+  });
+
+  it('parses 256-color background', () => {
+    const result = parseAnsi('\x1b[48;5;21mtext\x1b[0m');
+    expect(result.segments[0].bg).toBeDefined();
+  });
+
+  // ---- 24-bit (truecolor) mode ----
+
+  it('parses 24-bit foreground color', () => {
+    const result = parseAnsi('\x1b[38;2;255;128;0mtext\x1b[0m');
+    expect(result.segments[0].fg).toBe('#ff8000');
+  });
+
+  it('parses 24-bit background color', () => {
+    const result = parseAnsi('\x1b[48;2;0;64;128mtext\x1b[0m');
+    expect(result.segments[0].bg).toBe('#004080');
+  });
+
+  // ---- Text attributes ----
+
+  it('parses bold', () => {
+    const result = parseAnsi('\x1b[1mtext\x1b[0m');
+    expect(result.segments[0].bold).toBe(true);
+  });
+
+  it('parses dim', () => {
+    const result = parseAnsi('\x1b[2mtext\x1b[0m');
+    expect(result.segments[0].dim).toBe(true);
+  });
+
+  it('parses italic', () => {
+    const result = parseAnsi('\x1b[3mtext\x1b[0m');
+    expect(result.segments[0].italic).toBe(true);
+  });
+
+  it('parses underline', () => {
+    const result = parseAnsi('\x1b[4mtext\x1b[0m');
+    expect(result.segments[0].underline).toBe(true);
+  });
+
+  it('parses strikethrough', () => {
+    const result = parseAnsi('\x1b[9mtext\x1b[0m');
+    expect(result.segments[0].strikethrough).toBe(true);
+  });
+
+  it('parses combined attributes', () => {
+    const result = parseAnsi('\x1b[1;3;31mtext\x1b[0m');
+    expect(result.segments[0]).toEqual({
+      text: 'text',
+      fg: '#cc0000',
+      bold: true,
+      italic: true,
+    });
+  });
+
+  // ---- Attribute resets ----
+
+  it('resets bold with SGR 22', () => {
+    const result = parseAnsi('\x1b[1mbold\x1b[22mnormal\x1b[0m');
+    expect(result.segments[0].bold).toBe(true);
+    expect(result.segments[1].bold).toBeUndefined();
+  });
+
+  it('resets italic with SGR 23', () => {
+    const result = parseAnsi('\x1b[3mitalic\x1b[23mnormal\x1b[0m');
+    expect(result.segments[0].italic).toBe(true);
+    expect(result.segments[1].italic).toBeUndefined();
+  });
+
+  it('resets foreground with SGR 39', () => {
+    const result = parseAnsi('\x1b[31mred\x1b[39mnormal\x1b[0m');
+    expect(result.segments[0].fg).toBe('#cc0000');
+    expect(result.segments[1].fg).toBeUndefined();
+  });
+
+  it('resets background with SGR 49', () => {
+    const result = parseAnsi('\x1b[41mred bg\x1b[49mnormal\x1b[0m');
+    expect(result.segments[0].bg).toBe('#cc0000');
+    expect(result.segments[1].bg).toBeUndefined();
+  });
+
+  // ---- Bare ESC[m ----
+
+  it('treats bare ESC[m as reset', () => {
+    const result = parseAnsi('\x1b[31mred\x1b[mnormal');
+    expect(result.segments[0].fg).toBe('#cc0000');
+    expect(result.segments[1].fg).toBeUndefined();
+  });
+
+  // ---- Segment merging ----
+
+  it('merges consecutive segments with same style', () => {
+    // Two red segments back-to-back should merge
+    const result = parseAnsi('\x1b[31mhello \x1b[31mworld\x1b[0m');
+    expect(result.segments).toHaveLength(1);
+    expect(result.segments[0].text).toBe('hello world');
+    expect(result.segments[0].fg).toBe('#cc0000');
+  });
+
+  // ---- All-default optimization ----
+
+  it('returns empty segments when ANSI is present but only resets', () => {
+    const result = parseAnsi('\x1b[0mhello world');
+    expect(result.plain).toBe('hello world');
+    expect(result.hasAnsi).toBe(true);
+    expect(result.segments).toEqual([]); // all-default optimization
+  });
+
+  // ---- Non-SGR CSI sequences ----
+
+  it('skips non-SGR CSI sequences (cursor movement)', () => {
+    const result = parseAnsi('\x1b[2Ahello');
+    expect(result.plain).toBe('hello');
+    expect(result.hasAnsi).toBe(true);
+  });
+
+  // ---- OSC sequences ----
+
+  it('skips OSC sequence with BEL', () => {
+    const result = parseAnsi('\x1b]0;Title\x07hello');
+    expect(result.plain).toBe('hello');
+  });
+
+  it('skips OSC sequence with ST', () => {
+    const result = parseAnsi('\x1b]8;;https://example.com\x1b\\link text\x1b]8;;\x1b\\');
+    expect(result.plain).toBe('link text');
+  });
+
+  // ---- Two-byte escapes ----
+
+  it('skips charset designation', () => {
+    const result = parseAnsi('\x1b(Bhello');
+    expect(result.plain).toBe('hello');
+  });
+
+  // ---- Realistic log lines ----
+
+  it('handles typical Go structured log', () => {
+    const input = '\x1b[90m2024-01-15T10:30:00Z\x1b[0m \x1b[1;31mERROR\x1b[0m \x1b[36mmain.go:42\x1b[0m Failed to connect';
+    const result = parseAnsi(input);
+
+    expect(result.plain).toBe('2024-01-15T10:30:00Z ERROR main.go:42 Failed to connect');
+    // 6 segments: timestamp(gray), space, ERROR(bold red), space, file(cyan), trailing text
+    expect(result.segments).toHaveLength(6);
+
+    expect(result.segments[0]).toEqual({ text: '2024-01-15T10:30:00Z', fg: '#555753' });
+    expect(result.segments[1]).toEqual({ text: ' ' });
+    expect(result.segments[2]).toEqual({ text: 'ERROR', fg: '#cc0000', bold: true });
+    expect(result.segments[3]).toEqual({ text: ' ' });
+    expect(result.segments[4]).toEqual({ text: 'main.go:42', fg: '#06989a' });
+    expect(result.segments[5]).toEqual({ text: ' Failed to connect' });
+  });
+
+  it('handles kubectl multi-container log', () => {
+    const input = '\x1b[33m[nginx]\x1b[0m \x1b[32m192.168.1.1\x1b[0m - GET /healthz 200';
+    const result = parseAnsi(input);
+
+    expect(result.plain).toBe('[nginx] 192.168.1.1 - GET /healthz 200');
+  });
+
+  it('handles Python traceback coloring', () => {
+    const input = '\x1b[1;31mTraceback (most recent call last):\x1b[0m\n  File "main.py", line 10';
+    const result = parseAnsi(input);
+
+    expect(result.plain).toBe('Traceback (most recent call last):\n  File "main.py", line 10');
+    expect(result.segments[0].bold).toBe(true);
+    expect(result.segments[0].fg).toBe('#cc0000');
+  });
+
+  // ---- Edge cases ----
+
+  it('handles escape at end of string', () => {
+    const result = parseAnsi('hello\x1b');
+    expect(result.plain).toBe('hello');
+  });
+
+  it('handles incomplete CSI sequence', () => {
+    const result = parseAnsi('hello\x1b[');
+    expect(result.plain).toBe('hello');
+  });
+
+  it('handles consecutive escape sequences with no text between', () => {
+    const result = parseAnsi('\x1b[1m\x1b[31m\x1b[4mtext\x1b[0m');
+    expect(result.segments[0].bold).toBe(true);
+    expect(result.segments[0].fg).toBe('#cc0000');
+    expect(result.segments[0].underline).toBe(true);
+  });
+
+  it('preserves whitespace and special chars', () => {
+    const result = parseAnsi('\x1b[31m  tabs\there  \x1b[0m');
+    expect(result.plain).toBe('  tabs\there  ');
+    expect(result.segments[0].text).toBe('  tabs\there  ');
+  });
+
+  // ---- Pathological input ----
+
+  it('handles pathological input with many escape sequences', () => {
+    let input = '';
+    for (let i = 0; i < 100; i++) {
+      input += `\x1b[${30 + (i % 8)}mword${i} `;
+    }
+    input += '\x1b[0m';
+
+    const result = parseAnsi(input);
+    expect(result.plain).toContain('word0');
+    expect(result.plain).toContain('word99');
+    expect(result.hasAnsi).toBe(true);
+  });
+
+  // Performance benchmarks live in parseAnsi.bench.ts — run with `vitest bench`.
+});

--- a/ui/providers/BottomDrawer/containers/LogViewer/utils/parseAnsi.ts
+++ b/ui/providers/BottomDrawer/containers/LogViewer/utils/parseAnsi.ts
@@ -27,16 +27,8 @@
  *   100-107  bright background
  */
 
-export interface AnsiSegment {
-  text: string;
-  fg?: string;
-  bg?: string;
-  bold?: boolean;
-  dim?: boolean;
-  italic?: boolean;
-  underline?: boolean;
-  strikethrough?: boolean;
-}
+import type { AnsiSegment } from '../types';
+export type { AnsiSegment };
 
 export interface ParsedAnsi {
   /** Plain text with all escape sequences removed (for search, level detection). */
@@ -319,7 +311,7 @@ export function parseAnsi(input: string): ParsedAnsi {
 
   const plain = plainParts.join('');
 
-  if (allDefault) {
+  if (allDefault || segments.length === 0) {
     return { plain, segments: [], hasAnsi: true };
   }
 

--- a/ui/providers/BottomDrawer/containers/LogViewer/utils/parseAnsi.ts
+++ b/ui/providers/BottomDrawer/containers/LogViewer/utils/parseAnsi.ts
@@ -1,0 +1,342 @@
+/**
+ * Single-pass ANSI SGR parser.
+ *
+ * Produces an array of styled text segments and a stripped plain-text string
+ * in one scan. Designed for hot-path usage at log ingest (100k+ lines).
+ *
+ * Supported SGR codes:
+ *   0        reset
+ *   1        bold
+ *   2        dim
+ *   3        italic
+ *   4        underline
+ *   9        strikethrough
+ *   22       normal intensity (not bold/dim)
+ *   23       not italic
+ *   24       not underline
+ *   29       not strikethrough
+ *   30-37    standard foreground
+ *   38;5;N   256-color foreground
+ *   38;2;R;G;B  24-bit foreground
+ *   39       default foreground
+ *   40-47    standard background
+ *   48;5;N   256-color background
+ *   48;2;R;G;B  24-bit background
+ *   49       default background
+ *   90-97    bright foreground
+ *   100-107  bright background
+ */
+
+export interface AnsiSegment {
+  text: string;
+  fg?: string;
+  bg?: string;
+  bold?: boolean;
+  dim?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  strikethrough?: boolean;
+}
+
+export interface ParsedAnsi {
+  /** Plain text with all escape sequences removed (for search, level detection). */
+  plain: string;
+  /** Styled segments for rendering. Empty array if input has no ANSI codes. */
+  segments: AnsiSegment[];
+  /** True if the input contained any ANSI escape sequences. */
+  hasAnsi: boolean;
+}
+
+// Standard 8 ANSI colors (SGR 30-37 / 40-47).
+const STANDARD_COLORS = [
+  '#000000', // black
+  '#cc0000', // red
+  '#4e9a06', // green
+  '#c4a000', // yellow
+  '#3465a4', // blue
+  '#75507b', // magenta
+  '#06989a', // cyan
+  '#d3d7cf', // white
+] as const;
+
+// Bright 8 ANSI colors (SGR 90-97 / 100-107).
+const BRIGHT_COLORS = [
+  '#555753', // bright black (gray)
+  '#ef2929', // bright red
+  '#8ae234', // bright green
+  '#fce94f', // bright yellow
+  '#729fcf', // bright blue
+  '#ad7fa8', // bright magenta
+  '#34e2e2', // bright cyan
+  '#eeeeec', // bright white
+] as const;
+
+// 6×6×6 color cube (indices 16-231 of 256-color palette).
+// Pre-computed for zero allocation at parse time.
+const COLOR_CUBE: string[] = new Array(216);
+for (let r = 0; r < 6; r++) {
+  for (let g = 0; g < 6; g++) {
+    for (let b = 0; b < 6; b++) {
+      const ri = r ? r * 40 + 55 : 0;
+      const gi = g ? g * 40 + 55 : 0;
+      const bi = b ? b * 40 + 55 : 0;
+      COLOR_CUBE[r * 36 + g * 6 + b] = `#${hex(ri)}${hex(gi)}${hex(bi)}`;
+    }
+  }
+}
+
+// Grayscale ramp (indices 232-255 of 256-color palette).
+const GRAYSCALE: string[] = new Array(24);
+for (let i = 0; i < 24; i++) {
+  const v = i * 10 + 8;
+  GRAYSCALE[i] = `#${hex(v)}${hex(v)}${hex(v)}`;
+}
+
+function hex(n: number): string {
+  return n.toString(16).padStart(2, '0');
+}
+
+/** Resolve a 256-color palette index to a CSS hex color. */
+function color256(n: number): string | undefined {
+  if (n < 0 || n > 255) return undefined;
+  if (n < 8) return STANDARD_COLORS[n];
+  if (n < 16) return BRIGHT_COLORS[n - 8];
+  if (n < 232) return COLOR_CUBE[n - 16];
+  return GRAYSCALE[n - 232];
+}
+
+interface Style {
+  fg: string | undefined;
+  bg: string | undefined;
+  bold: boolean;
+  dim: boolean;
+  italic: boolean;
+  underline: boolean;
+  strikethrough: boolean;
+}
+
+function resetStyle(): Style {
+  return { fg: undefined, bg: undefined, bold: false, dim: false, italic: false, underline: false, strikethrough: false };
+}
+
+function toSegment(text: string, style: Style): AnsiSegment {
+  const seg: AnsiSegment = { text };
+  if (style.fg) seg.fg = style.fg;
+  if (style.bg) seg.bg = style.bg;
+  if (style.bold) seg.bold = true;
+  if (style.dim) seg.dim = true;
+  if (style.italic) seg.italic = true;
+  if (style.underline) seg.underline = true;
+  if (style.strikethrough) seg.strikethrough = true;
+  return seg;
+}
+
+/**
+ * Apply an array of SGR parameter numbers to the current style (mutates `style`).
+ */
+function applySgr(params: number[], style: Style): void {
+  let i = 0;
+  while (i < params.length) {
+    const code = params[i];
+    switch (code) {
+      case 0: // reset
+        style.fg = undefined;
+        style.bg = undefined;
+        style.bold = false;
+        style.dim = false;
+        style.italic = false;
+        style.underline = false;
+        style.strikethrough = false;
+        break;
+      case 1: style.bold = true; break;
+      case 2: style.dim = true; break;
+      case 3: style.italic = true; break;
+      case 4: style.underline = true; break;
+      case 9: style.strikethrough = true; break;
+      case 22: style.bold = false; style.dim = false; break;
+      case 23: style.italic = false; break;
+      case 24: style.underline = false; break;
+      case 29: style.strikethrough = false; break;
+      case 39: style.fg = undefined; break;
+      case 49: style.bg = undefined; break;
+      default:
+        // Standard foreground: 30-37
+        if (code >= 30 && code <= 37) {
+          style.fg = STANDARD_COLORS[code - 30];
+        }
+        // Standard background: 40-47
+        else if (code >= 40 && code <= 47) {
+          style.bg = STANDARD_COLORS[code - 40];
+        }
+        // Bright foreground: 90-97
+        else if (code >= 90 && code <= 97) {
+          style.fg = BRIGHT_COLORS[code - 90];
+        }
+        // Bright background: 100-107
+        else if (code >= 100 && code <= 107) {
+          style.bg = BRIGHT_COLORS[code - 100];
+        }
+        // Extended foreground: 38;5;N or 38;2;R;G;B
+        else if (code === 38 && i + 1 < params.length) {
+          if (params[i + 1] === 5 && i + 2 < params.length) {
+            style.fg = color256(params[i + 2]);
+            i += 2;
+          } else if (params[i + 1] === 2 && i + 4 < params.length) {
+            style.fg = `#${hex(params[i + 2] & 0xff)}${hex(params[i + 3] & 0xff)}${hex(params[i + 4] & 0xff)}`;
+            i += 4;
+          }
+        }
+        // Extended background: 48;5;N or 48;2;R;G;B
+        else if (code === 48 && i + 1 < params.length) {
+          if (params[i + 1] === 5 && i + 2 < params.length) {
+            style.bg = color256(params[i + 2]);
+            i += 2;
+          } else if (params[i + 1] === 2 && i + 4 < params.length) {
+            style.bg = `#${hex(params[i + 2] & 0xff)}${hex(params[i + 3] & 0xff)}${hex(params[i + 4] & 0xff)}`;
+            i += 4;
+          }
+        }
+        break;
+    }
+    i++;
+  }
+}
+
+/**
+ * Parse a string containing ANSI escape sequences into styled segments.
+ *
+ * Single-pass, zero-regex implementation for maximum throughput.
+ * Returns both the styled segments and the plain (stripped) text.
+ */
+export function parseAnsi(input: string): ParsedAnsi {
+  const len = input.length;
+
+  // Fast path: no ESC byte at all → return as-is, zero allocation beyond the result.
+  if (input.indexOf('\x1b') === -1) {
+    return { plain: input, segments: [], hasAnsi: false };
+  }
+
+  const segments: AnsiSegment[] = [];
+  const plainParts: string[] = [];
+  let style = resetStyle();
+  let textStart = 0;
+  let i = 0;
+
+  while (i < len) {
+    if (input.charCodeAt(i) === 0x1b /* ESC */) {
+      // Flush text accumulated before this escape.
+      if (i > textStart) {
+        const text = input.substring(textStart, i);
+        segments.push(toSegment(text, style));
+        plainParts.push(text);
+      }
+
+      // Check for CSI sequence: ESC [
+      if (i + 1 < len && input.charCodeAt(i + 1) === 0x5b /* [ */) {
+        // Parse CSI parameters.
+        let j = i + 2;
+        while (j < len) {
+          const c = input.charCodeAt(j);
+          // Parameter bytes: 0x30-0x3f  (digits 0-9, semicolon, etc.)
+          if (c >= 0x30 && c <= 0x3f) { j++; continue; }
+          // Intermediate bytes: 0x20-0x2f
+          if (c >= 0x20 && c <= 0x2f) { j++; continue; }
+          // Final byte: 0x40-0x7e
+          break;
+        }
+
+        if (j < len) {
+          const finalByte = input.charCodeAt(j);
+          // Only process SGR ('m' = 0x6d) sequences for styling.
+          if (finalByte === 0x6d) {
+            const paramStr = input.substring(i + 2, j);
+            if (paramStr === '' || paramStr === '0') {
+              // Common case: bare ESC[m or ESC[0m → full reset.
+              style = resetStyle();
+            } else {
+              const params = paramStr.split(';').map(s => (s === '' ? 0 : parseInt(s, 10)));
+              applySgr(params, style);
+            }
+          }
+          // Skip past the final byte regardless of whether we handled it.
+          i = j + 1;
+        } else {
+          // Malformed: no final byte found. Skip the ESC[.
+          i = j;
+        }
+        textStart = i;
+        continue;
+      }
+
+      // OSC sequence: ESC ]  ... BEL or ST
+      if (i + 1 < len && input.charCodeAt(i + 1) === 0x5d /* ] */) {
+        let j = i + 2;
+        while (j < len) {
+          // BEL (0x07) terminates OSC
+          if (input.charCodeAt(j) === 0x07) { j++; break; }
+          // ST (ESC \) terminates OSC
+          if (input.charCodeAt(j) === 0x1b && j + 1 < len && input.charCodeAt(j + 1) === 0x5c) { j += 2; break; }
+          j++;
+        }
+        i = j;
+        textStart = i;
+        continue;
+      }
+
+      // Charset designation: ESC ( <char> or ESC ) <char> — 3 bytes total.
+      if (i + 2 < len && (input.charCodeAt(i + 1) === 0x28 || input.charCodeAt(i + 1) === 0x29)) {
+        i += 3;
+        textStart = i;
+        continue;
+      }
+
+      // Other two-byte escape (ESC + single char): skip both.
+      i += 2;
+      textStart = i;
+      continue;
+    }
+
+    i++;
+  }
+
+  // Flush remaining text.
+  if (textStart < len) {
+    const text = input.substring(textStart);
+    segments.push(toSegment(text, style));
+    plainParts.push(text);
+  }
+
+  // Optimization: if all segments have default style, collapse to hasAnsi=true
+  // but return empty segments to signal the caller can use plain text directly.
+  let allDefault = true;
+  for (let s = 0; s < segments.length; s++) {
+    const seg = segments[s];
+    if (seg.fg || seg.bg || seg.bold || seg.dim || seg.italic || seg.underline || seg.strikethrough) {
+      allDefault = false;
+      break;
+    }
+  }
+
+  const plain = plainParts.join('');
+
+  if (allDefault) {
+    return { plain, segments: [], hasAnsi: true };
+  }
+
+  // Merge consecutive segments with identical styles to minimize span count.
+  const merged: AnsiSegment[] = [segments[0]];
+  for (let s = 1; s < segments.length; s++) {
+    const prev = merged[merged.length - 1];
+    const curr = segments[s];
+    if (prev.fg === curr.fg && prev.bg === curr.bg && prev.bold === curr.bold
+      && prev.dim === curr.dim && prev.italic === curr.italic
+      && prev.underline === curr.underline && prev.strikethrough === curr.strikethrough) {
+      // Merge by concatenating text.
+      merged[merged.length - 1] = { ...prev, text: prev.text + curr.text };
+    } else {
+      merged.push(curr);
+    }
+  }
+
+  return { plain, segments: merged, hasAnsi: true };
+}

--- a/ui/providers/BottomDrawer/containers/LogViewer/utils/parseLogLine.spec.ts
+++ b/ui/providers/BottomDrawer/containers/LogViewer/utils/parseLogLine.spec.ts
@@ -156,6 +156,14 @@ describe('parseRawLogLine', () => {
     expect(entry.ansiSegments).toBeUndefined();
   });
 
+  it('handles escape-only content (no visible text)', () => {
+    const entry = parseRawLogLine(makeRaw({ content: '\x1b[31m\x1b[0m' }), 1);
+    expect(entry.content).toBe('');
+    expect(entry.ansiSegments).toBeUndefined();
+    expect(entry.level).toBeUndefined();
+    expect(entry.isJson).toBe(false);
+  });
+
   // ---- Edge cases ----
 
   it('handles empty content', () => {

--- a/ui/providers/BottomDrawer/containers/LogViewer/utils/parseLogLine.spec.ts
+++ b/ui/providers/BottomDrawer/containers/LogViewer/utils/parseLogLine.spec.ts
@@ -118,6 +118,44 @@ describe('parseRawLogLine', () => {
     expect(entry.content).toBe('Hi');
   });
 
+  // ---- ANSI escape sequence handling ----
+
+  it('strips ANSI codes from content', () => {
+    const entry = parseRawLogLine(makeRaw({ content: '\x1b[31mERROR\x1b[0m something broke' }), 1);
+    expect(entry.content).toBe('ERROR something broke');
+  });
+
+  it('detects level through ANSI codes', () => {
+    const entry = parseRawLogLine(makeRaw({ content: '\x1b[1;31mERROR\x1b[0m database down' }), 1);
+    expect(entry.level).toBe('error');
+  });
+
+  it('populates ansiSegments for colored content', () => {
+    const entry = parseRawLogLine(makeRaw({ content: '\x1b[31mERROR\x1b[0m normal' }), 1);
+    expect(entry.ansiSegments).toBeDefined();
+    expect(entry.ansiSegments).toHaveLength(2);
+    expect(entry.ansiSegments![0].fg).toBe('#cc0000');
+    expect(entry.ansiSegments![0].text).toBe('ERROR');
+    expect(entry.ansiSegments![1].text).toBe(' normal');
+  });
+
+  it('omits ansiSegments for plain content', () => {
+    const entry = parseRawLogLine(makeRaw({ content: 'plain text' }), 1);
+    expect(entry.ansiSegments).toBeUndefined();
+  });
+
+  it('detects JSON in ANSI-wrapped content', () => {
+    const entry = parseRawLogLine(makeRaw({ content: '\x1b[32m{"key":"value"}\x1b[0m' }), 1);
+    expect(entry.content).toBe('{"key":"value"}');
+    expect(entry.isJson).toBe(true);
+  });
+
+  it('omits ansiSegments when ANSI codes are present but only resets', () => {
+    const entry = parseRawLogLine(makeRaw({ content: '\x1b[0mplain text' }), 1);
+    expect(entry.content).toBe('plain text');
+    expect(entry.ansiSegments).toBeUndefined();
+  });
+
   // ---- Edge cases ----
 
   it('handles empty content', () => {

--- a/ui/providers/BottomDrawer/containers/LogViewer/utils/stripAnsi.bench.ts
+++ b/ui/providers/BottomDrawer/containers/LogViewer/utils/stripAnsi.bench.ts
@@ -1,0 +1,64 @@
+import { bench, describe } from 'vitest';
+import { stripAnsi } from './stripAnsi';
+
+// ---------------------------------------------------------------------------
+// Test data — representative of real Kubernetes pod log lines
+// ---------------------------------------------------------------------------
+
+const PLAIN_SHORT = '2024-01-15T10:30:00Z INFO server started on :8080';
+const PLAIN_LONG = `2024-01-15T10:30:00.123456Z INFO  [request_id=abc-123-def-456] GET /api/v1/namespaces/kube-system/pods?labelSelector=app%3Dcoredns&limit=500 responded 200 in 12.34ms (bytes_in=0, bytes_out=48291, user_agent="kubectl/v1.28.0")`;
+
+const COLORED_SIMPLE = '\x1b[31mERROR\x1b[0m something broke';
+const COLORED_TYPICAL = '\x1b[90m2024-01-15T10:30:00Z\x1b[0m \x1b[1;31mERROR\x1b[0m \x1b[36mmain.go:42\x1b[0m Failed to connect to \x1b[33mdatabase\x1b[0m service';
+const COLORED_HEAVY = '\x1b[1m\x1b[38;2;255;128;0m2024-01-15\x1b[0m \x1b[48;5;196m\x1b[38;5;231mERROR\x1b[0m \x1b[3m\x1b[4m\x1b[38;2;100;200;50mcontroller.go:127\x1b[0m \x1b[2mFailed to reconcile \x1b[1;33mDeployment\x1b[0m/\x1b[36mnginx-ingress\x1b[0m in namespace \x1b[35mkube-system\x1b[0m: \x1b[91mconnection refused\x1b[0m';
+
+// Pre-build a batch to simulate ingesting a chunk of log lines at once.
+const BATCH_MIXED_100 = Array.from({ length: 100 }, (_, i) => {
+  if (i % 3 === 0) return COLORED_TYPICAL;
+  if (i % 3 === 1) return PLAIN_LONG;
+  return COLORED_HEAVY;
+});
+
+const BATCH_PLAIN_100 = Array.from({ length: 100 }, () => PLAIN_LONG);
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+describe('stripAnsi', () => {
+  describe('single line', () => {
+    bench('plain short (fast path)', () => {
+      stripAnsi(PLAIN_SHORT);
+    });
+
+    bench('plain long (fast path)', () => {
+      stripAnsi(PLAIN_LONG);
+    });
+
+    bench('colored simple (1 SGR pair)', () => {
+      stripAnsi(COLORED_SIMPLE);
+    });
+
+    bench('colored typical (4 SGR pairs)', () => {
+      stripAnsi(COLORED_TYPICAL);
+    });
+
+    bench('colored heavy (256-color, RGB, attributes)', () => {
+      stripAnsi(COLORED_HEAVY);
+    });
+  });
+
+  describe('batch (simulates ingest chunk)', () => {
+    bench('100 mixed lines', () => {
+      for (let i = 0; i < BATCH_MIXED_100.length; i++) {
+        stripAnsi(BATCH_MIXED_100[i]);
+      }
+    });
+
+    bench('100 plain lines (fast path)', () => {
+      for (let i = 0; i < BATCH_PLAIN_100.length; i++) {
+        stripAnsi(BATCH_PLAIN_100[i]);
+      }
+    });
+  });
+});

--- a/ui/providers/BottomDrawer/containers/LogViewer/utils/stripAnsi.spec.ts
+++ b/ui/providers/BottomDrawer/containers/LogViewer/utils/stripAnsi.spec.ts
@@ -1,0 +1,97 @@
+import { stripAnsi } from './stripAnsi';
+
+describe('stripAnsi', () => {
+  // ---- Fast path ----
+
+  it('returns plain text as-is (no allocation)', () => {
+    const input = 'hello world';
+    expect(stripAnsi(input)).toBe(input); // same reference
+  });
+
+  it('returns empty string as-is', () => {
+    expect(stripAnsi('')).toBe('');
+  });
+
+  // ---- SGR (color/style) sequences ----
+
+  it('strips basic SGR reset', () => {
+    expect(stripAnsi('\x1b[0mhello')).toBe('hello');
+  });
+
+  it('strips foreground color', () => {
+    expect(stripAnsi('\x1b[31mERROR\x1b[0m')).toBe('ERROR');
+  });
+
+  it('strips bold + color combo', () => {
+    expect(stripAnsi('\x1b[1;33mWARN\x1b[0m: something')).toBe('WARN: something');
+  });
+
+  it('strips multiple colors in one line', () => {
+    expect(stripAnsi('\x1b[32mGREEN\x1b[0m and \x1b[34mBLUE\x1b[0m')).toBe('GREEN and BLUE');
+  });
+
+  it('strips 256-color foreground', () => {
+    expect(stripAnsi('\x1b[38;5;196mred text\x1b[0m')).toBe('red text');
+  });
+
+  it('strips 24-bit RGB foreground', () => {
+    expect(stripAnsi('\x1b[38;2;255;128;0morange\x1b[0m')).toBe('orange');
+  });
+
+  it('strips background colors', () => {
+    expect(stripAnsi('\x1b[41mred bg\x1b[0m')).toBe('red bg');
+  });
+
+  it('strips bright colors (90-97)', () => {
+    expect(stripAnsi('\x1b[91mbright red\x1b[0m')).toBe('bright red');
+  });
+
+  // ---- CSI sequences (cursor, erase, etc.) ----
+
+  it('strips cursor movement sequences', () => {
+    expect(stripAnsi('\x1b[2Ahello')).toBe('hello');  // cursor up
+    expect(stripAnsi('\x1b[5Bhello')).toBe('hello');  // cursor down
+    expect(stripAnsi('\x1b[10Chello')).toBe('hello'); // cursor forward
+    expect(stripAnsi('\x1b[3Dhello')).toBe('hello');  // cursor back
+  });
+
+  it('strips erase sequences', () => {
+    expect(stripAnsi('\x1b[2Jhello')).toBe('hello'); // erase screen
+    expect(stripAnsi('\x1b[Khello')).toBe('hello');  // erase to end of line
+  });
+
+  // ---- OSC sequences ----
+
+  it('strips OSC with BEL terminator', () => {
+    expect(stripAnsi('\x1b]0;Window Title\x07hello')).toBe('hello');
+  });
+
+  it('strips OSC with ST terminator', () => {
+    expect(stripAnsi('\x1b]0;Title\x1b\\hello')).toBe('hello');
+  });
+
+  // ---- Two-byte escapes ----
+
+  it('strips charset designation', () => {
+    expect(stripAnsi('\x1b(Bhello')).toBe('hello');
+  });
+
+  // ---- Realistic log lines ----
+
+  it('handles a typical Go log with color', () => {
+    const input = '\x1b[36m2024-01-15T10:30:00Z\x1b[0m \x1b[1;31mERROR\x1b[0m Failed to connect to database';
+    expect(stripAnsi(input)).toBe('2024-01-15T10:30:00Z ERROR Failed to connect to database');
+  });
+
+  it('handles a kubectl log line with namespace coloring', () => {
+    const input = '\x1b[33m[kube-system]\x1b[0m \x1b[32mcoredns-5d78c9869d-abc12\x1b[0m Starting DNS server';
+    expect(stripAnsi(input)).toBe('[kube-system] coredns-5d78c9869d-abc12 Starting DNS server');
+  });
+
+  it('handles nested/multiple escape codes', () => {
+    const input = '\x1b[1m\x1b[4m\x1b[31mBOLD UNDERLINE RED\x1b[0m normal';
+    expect(stripAnsi(input)).toBe('BOLD UNDERLINE RED normal');
+  });
+
+  // Performance benchmarks live in stripAnsi.bench.ts — run with `vitest bench`.
+});

--- a/ui/providers/BottomDrawer/containers/LogViewer/utils/stripAnsi.ts
+++ b/ui/providers/BottomDrawer/containers/LogViewer/utils/stripAnsi.ts
@@ -1,0 +1,19 @@
+/**
+ * Fast ANSI escape sequence stripper.
+ *
+ * Matches all common ANSI/VT escape sequences:
+ *  - CSI sequences:  ESC [ ... <final>        (colors, cursor, erase, etc.)
+ *  - OSC sequences:  ESC ] ... BEL/ST         (title, hyperlinks)
+ *  - Two-char seqs:  ESC <letter>             (charset designation, etc.)
+ *
+ * Uses a single pre-compiled regex — benchmarks at <1µs per typical log line.
+ */
+
+// eslint-disable-next-line no-control-regex
+const ANSI_RE = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nq-uy=><~]|\u001b\].*?(?:\u0007|\u001b\\)/g;
+
+export function stripAnsi(str: string): string {
+  // Fast path: if there's no ESC or CSI byte, return as-is (avoids regex overhead).
+  if (str.indexOf('\u001b') === -1 && str.indexOf('\u009b') === -1) return str;
+  return str.replace(ANSI_RE, '');
+}

--- a/vitest.bench.config.ts
+++ b/vitest.bench.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(import.meta.dirname, './ui'),
+    },
+  },
+  test: {
+    benchmark: {
+      include: ['**/*.bench.ts'],
+      outputJson: './benchmarks/results.json',
+    },
+  },
+});


### PR DESCRIPTION
## Summary
   - Log lines with ANSI escape codes (colors, bold, etc.) rendered as rectangles/tofu in the log viewer — now parsed and rendered as colored styled spans
   - Single-pass zero-regex ANSI SGR parser at ingest time supports standard/bright/256-color/24-bit RGB and text attributes (bold, dim, italic, underline, strikethrough)
   - `stripAnsi` utility available as a fast-path fallback for no-color mode
   - Search, level detection, and log download all operate on stripped plain text so they work correctly regardless of ANSI codes
   - Vitest bench suite added for performance regression tracking (`pnpm bench`)

   ## Test plan
   - [x] 152 unit tests pass (parseAnsi, stripAnsi, parseLogLine, LogEntry, LogViewer)
   - [x] TypeScript compiles cleanly
   - [x] Benchmarks: parseAnsi handles 100k mixed lines in ~183ms, plain text fast path at 15M ops/sec
   - [x] Manual: connect to a cluster with colored log output, verify colors render and no rectangles appear
   - [x] Manual: search within colored logs, verify highlights overlay correctly on colored text


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Log viewer renders ANSI-colored logs with accurate styles and a Palette toggle to enable/disable colorized output.
  * Search highlighting correctly overlays matches across colored text, including across color boundaries.

* **Tests**
  * Expanded unit and benchmark suites for ANSI parsing, stripping, rendering, and large-batch performance.

* **Chores**
  * Added benchmarking config, npm bench script, and gitignore entry for benchmark outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->