### PR TITLE
fix: log search matches new entries as they stream in + refactor

### DIFF
--- a/ui/providers/BottomDrawer/containers/LogViewer/hooks/__tests__/useLogSearch.test.ts
+++ b/ui/providers/BottomDrawer/containers/LogViewer/hooks/__tests__/useLogSearch.test.ts
@@ -1,0 +1,575 @@
+import { renderHook, act } from '@testing-library/react';
+import { useLogSearch } from '../useLogSearch';
+import { MAX_MATCH_COUNT } from '../../utils/regexSafety';
+import type { LogEntry } from '../../types';
+
+/** Helper to build a minimal LogEntry with the given content. */
+function entry(content: string, idx = 0): LogEntry {
+  return {
+    lineNumber: idx,
+    sessionId: 's1',
+    sourceId: 'src1',
+    labels: {},
+    timestamp: '',
+    content,
+    origin: 'CURRENT',
+  };
+}
+
+describe('useLogSearch', () => {
+  // ---------------------------------------------------------------------------
+  // Basic behavior
+  // ---------------------------------------------------------------------------
+
+  it('returns no matches when query is empty', () => {
+    const entries = [entry('hello'), entry('world')];
+    const { result } = renderHook(() =>
+      useLogSearch({ entries, version: 1, evictionCount: 0 }),
+    );
+
+    expect(result.current.matches).toEqual([]);
+    expect(result.current.totalMatches).toBe(0);
+    expect(result.current.capped).toBe(false);
+  });
+
+  it('finds all matches on initial search', () => {
+    const entries = [entry('foo bar'), entry('baz'), entry('foo end')];
+    const { result } = renderHook(() =>
+      useLogSearch({ entries, version: 1, evictionCount: 0 }),
+    );
+
+    act(() => result.current.setQuery('foo'));
+
+    expect(result.current.matches).toHaveLength(2);
+    expect(result.current.matches[0]).toEqual({
+      lineIndex: 0,
+      startOffset: 0,
+      endOffset: 3,
+    });
+    expect(result.current.matches[1]).toEqual({
+      lineIndex: 2,
+      startOffset: 0,
+      endOffset: 3,
+    });
+  });
+
+  it('finds multiple matches per line', () => {
+    const entries = [entry('foo foo foo')];
+    const { result } = renderHook(() =>
+      useLogSearch({ entries, version: 1, evictionCount: 0 }),
+    );
+
+    act(() => result.current.setQuery('foo'));
+
+    expect(result.current.matches).toHaveLength(3);
+    expect(result.current.matches[0]).toEqual({ lineIndex: 0, startOffset: 0, endOffset: 3 });
+    expect(result.current.matches[1]).toEqual({ lineIndex: 0, startOffset: 4, endOffset: 7 });
+    expect(result.current.matches[2]).toEqual({ lineIndex: 0, startOffset: 8, endOffset: 11 });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Incremental search (same array ref, entries grow)
+  // ---------------------------------------------------------------------------
+
+  it('incrementally finds matches when entries grow (same array ref)', () => {
+    // Use a mutable array — mirrors real useLogBuffer behavior
+    const entries: LogEntry[] = [entry('foo bar'), entry('baz')];
+    let version = 1;
+
+    const { result, rerender } = renderHook(() =>
+      useLogSearch({ entries, version, evictionCount: 0 }),
+    );
+
+    act(() => result.current.setQuery('foo'));
+    expect(result.current.matches).toHaveLength(1);
+    expect(result.current.matches[0].lineIndex).toBe(0);
+
+    // Mutate the same array (like useLogBuffer does)
+    entries.push(entry('foo new'));
+    version = 2;
+    rerender();
+
+    expect(result.current.matches).toHaveLength(2);
+    // New match at index 2 — proves incremental search found it
+    expect(result.current.matches[1].lineIndex).toBe(2);
+  });
+
+  it('incremental search appends only new matches (does not re-scan old entries)', () => {
+    const entries: LogEntry[] = [entry('aaa'), entry('bbb')];
+    let version = 1;
+
+    const { result, rerender } = renderHook(() =>
+      useLogSearch({ entries, version, evictionCount: 0 }),
+    );
+
+    act(() => result.current.setQuery('aaa'));
+    expect(result.current.matches).toHaveLength(1);
+    expect(result.current.matches[0].lineIndex).toBe(0);
+
+    // Add entries where only one matches
+    entries.push(entry('ccc'), entry('aaa again'));
+    version = 2;
+    rerender();
+
+    expect(result.current.matches).toHaveLength(2);
+    // First match unchanged, second at index 3
+    expect(result.current.matches[0].lineIndex).toBe(0);
+    expect(result.current.matches[1].lineIndex).toBe(3);
+  });
+
+  it('incremental search with no new matches keeps existing results', () => {
+    const entries: LogEntry[] = [entry('foo bar')];
+    let version = 1;
+
+    const { result, rerender } = renderHook(() =>
+      useLogSearch({ entries, version, evictionCount: 0 }),
+    );
+
+    act(() => result.current.setQuery('foo'));
+    expect(result.current.matches).toHaveLength(1);
+
+    // Add entries with no matches
+    entries.push(entry('baz'), entry('qux'));
+    version = 2;
+    rerender();
+
+    // Should still have the same single match, not duplicated
+    expect(result.current.matches).toHaveLength(1);
+    expect(result.current.matches[0].lineIndex).toBe(0);
+    expect(result.current.capped).toBe(false);
+  });
+
+  // ---------------------------------------------------------------------------
+  // No-change path (same ref, same length, same params)
+  // ---------------------------------------------------------------------------
+
+  it('returns cached results when only version changes but length is the same', () => {
+    const entries: LogEntry[] = [entry('foo'), entry('bar')];
+    let version = 1;
+
+    const { result, rerender } = renderHook(() =>
+      useLogSearch({ entries, version, evictionCount: 0 }),
+    );
+
+    act(() => result.current.setQuery('foo'));
+    expect(result.current.matches).toHaveLength(1);
+
+    // Bump version without changing entries length — hits the no-change path
+    version = 2;
+    rerender();
+
+    expect(result.current.matches).toHaveLength(1);
+    expect(result.current.matches[0].lineIndex).toBe(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Full re-search triggers
+  // ---------------------------------------------------------------------------
+
+  it('does full re-search when query changes', () => {
+    const entries = [entry('foo bar'), entry('bar baz'), entry('foo baz')];
+    const { result } = renderHook(() =>
+      useLogSearch({ entries, version: 1, evictionCount: 0 }),
+    );
+
+    act(() => result.current.setQuery('foo'));
+    expect(result.current.matches).toHaveLength(2);
+
+    act(() => result.current.setQuery('bar'));
+    expect(result.current.matches).toHaveLength(2);
+    expect(result.current.matches[0].lineIndex).toBe(0);
+    expect(result.current.matches[1].lineIndex).toBe(1);
+  });
+
+  it('resets currentMatchIndex when query changes', () => {
+    const entries = [entry('aaa'), entry('aaa'), entry('bbb')];
+    const { result } = renderHook(() =>
+      useLogSearch({ entries, version: 1, evictionCount: 0 }),
+    );
+
+    act(() => result.current.setQuery('aaa'));
+    act(() => result.current.nextMatch());
+    expect(result.current.currentMatchIndex).toBe(1);
+
+    act(() => result.current.setQuery('bbb'));
+    expect(result.current.currentMatchIndex).toBe(0);
+  });
+
+  it('does full re-search when isRegex changes', () => {
+    const entries = [entry('foo.bar'), entry('fooXbar')];
+    const { result } = renderHook(() =>
+      useLogSearch({ entries, version: 1, evictionCount: 0 }),
+    );
+
+    // Literal mode — dot is escaped, only matches "foo.bar"
+    act(() => result.current.setQuery('foo.bar'));
+    expect(result.current.matches).toHaveLength(1);
+    expect(result.current.matches[0].lineIndex).toBe(0);
+
+    // Switch to regex mode — dot matches any char
+    act(() => result.current.setIsRegex(true));
+    expect(result.current.matches).toHaveLength(2);
+  });
+
+  it('does full re-search when caseSensitive changes', () => {
+    const entries = [entry('Hello'), entry('hello')];
+    const { result } = renderHook(() =>
+      useLogSearch({ entries, version: 1, evictionCount: 0 }),
+    );
+
+    act(() => result.current.setQuery('hello'));
+    // Case insensitive by default
+    expect(result.current.matches).toHaveLength(2);
+
+    act(() => result.current.setCaseSensitive(true));
+    expect(result.current.matches).toHaveLength(1);
+    expect(result.current.matches[0].lineIndex).toBe(1);
+  });
+
+  it('does full re-search when evictionCount changes', () => {
+    // Use new array ref because eviction implies the buffer was spliced
+    let entries = [entry('foo 1'), entry('foo 2'), entry('foo 3')];
+    let version = 1;
+    let evictionCount = 0;
+
+    const { result, rerender } = renderHook(() =>
+      useLogSearch({ entries, version, evictionCount }),
+    );
+
+    act(() => result.current.setQuery('foo'));
+    expect(result.current.matches).toHaveLength(3);
+
+    // Simulate eviction: remove first entry, bump evictionCount
+    entries = [entry('foo 2'), entry('foo 3')];
+    version = 2;
+    evictionCount = 1;
+    rerender();
+
+    expect(result.current.matches).toHaveLength(2);
+    expect(result.current.matches[0].lineIndex).toBe(0);
+    expect(result.current.matches[1].lineIndex).toBe(1);
+  });
+
+  it('does full re-search when entries ref changes (filter toggle)', () => {
+    const allEntries = [entry('foo 1'), entry('bar'), entry('foo 2')];
+    let entries = allEntries;
+    let version = 1;
+
+    const { result, rerender } = renderHook(() =>
+      useLogSearch({ entries, version, evictionCount: 0 }),
+    );
+
+    act(() => result.current.setQuery('foo'));
+    expect(result.current.matches).toHaveLength(2);
+
+    // New array ref (simulates filter toggle)
+    entries = [entry('foo 1'), entry('foo 2')];
+    version = 2;
+    rerender();
+
+    expect(result.current.matches).toHaveLength(2);
+    expect(result.current.matches[0].lineIndex).toBe(0);
+    expect(result.current.matches[1].lineIndex).toBe(1);
+  });
+
+  it('does full re-search when entries shrink (same ref)', () => {
+    const entries: LogEntry[] = [entry('foo a'), entry('foo b'), entry('foo c')];
+    let version = 1;
+
+    const { result, rerender } = renderHook(() =>
+      useLogSearch({ entries, version, evictionCount: 0 }),
+    );
+
+    act(() => result.current.setQuery('foo'));
+    expect(result.current.matches).toHaveLength(3);
+
+    // Shrink the same array
+    entries.length = 1;
+    version = 2;
+    rerender();
+
+    expect(result.current.matches).toHaveLength(1);
+    expect(result.current.matches[0].lineIndex).toBe(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Capped behavior
+  // ---------------------------------------------------------------------------
+
+  it('skips new entries when already capped (same array ref)', () => {
+    // Build a mutable array with enough matches to hit the cap
+    const entries: LogEntry[] = Array.from(
+      { length: MAX_MATCH_COUNT + 100 },
+      (_, i) => entry('match', i),
+    );
+    let version = 1;
+
+    const { result, rerender } = renderHook(() =>
+      useLogSearch({ entries, version, evictionCount: 0 }),
+    );
+
+    act(() => result.current.setQuery('match'));
+    expect(result.current.capped).toBe(true);
+    const cappedCount = result.current.totalMatches;
+
+    // Push more entries to the same array — should remain capped, count unchanged
+    entries.push(entry('match'), entry('match'));
+    version = 2;
+    rerender();
+
+    expect(result.current.capped).toBe(true);
+    expect(result.current.totalMatches).toBe(cappedCount);
+  });
+
+  it('incremental search can reach the cap', () => {
+    // Start near the cap
+    const entries: LogEntry[] = Array.from(
+      { length: MAX_MATCH_COUNT - 2 },
+      (_, i) => entry('m', i),
+    );
+    let version = 1;
+
+    const { result, rerender } = renderHook(() =>
+      useLogSearch({ entries, version, evictionCount: 0 }),
+    );
+
+    act(() => result.current.setQuery('m'));
+    expect(result.current.capped).toBe(false);
+    expect(result.current.totalMatches).toBe(MAX_MATCH_COUNT - 2);
+
+    // Add enough to exceed cap
+    entries.push(entry('m'), entry('m'), entry('m'), entry('m'), entry('m'));
+    version = 2;
+    rerender();
+
+    expect(result.current.capped).toBe(true);
+    expect(result.current.totalMatches).toBe(MAX_MATCH_COUNT);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Clear / reset
+  // ---------------------------------------------------------------------------
+
+  it('resets to zero matches on clear (empty entries + eviction bump)', () => {
+    let entries: LogEntry[] = [entry('foo'), entry('foo')];
+    let version = 1;
+    let evictionCount = 0;
+
+    const { result, rerender } = renderHook(() =>
+      useLogSearch({ entries, version, evictionCount }),
+    );
+
+    act(() => result.current.setQuery('foo'));
+    expect(result.current.matches).toHaveLength(2);
+
+    // Simulate clear
+    entries = [];
+    version = 2;
+    evictionCount = 1;
+    rerender();
+
+    expect(result.current.matches).toHaveLength(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Empty / edge cases
+  // ---------------------------------------------------------------------------
+
+  it('empty query returns no matches regardless of version changes', () => {
+    let version = 1;
+    const entries = [entry('foo')];
+
+    const { result, rerender } = renderHook(() =>
+      useLogSearch({ entries, version, evictionCount: 0 }),
+    );
+
+    expect(result.current.matches).toHaveLength(0);
+
+    version = 2;
+    rerender();
+    expect(result.current.matches).toHaveLength(0);
+  });
+
+  it('invalid regex returns no matches', () => {
+    const entries = [entry('foo')];
+    const { result } = renderHook(() =>
+      useLogSearch({ entries, version: 1, evictionCount: 0 }),
+    );
+
+    act(() => {
+      result.current.setIsRegex(true);
+      result.current.setQuery('[unclosed');
+    });
+
+    expect(result.current.matches).toHaveLength(0);
+  });
+
+  it('empty-match regex pattern returns no matches', () => {
+    const entries = [entry('foo')];
+    const { result } = renderHook(() =>
+      useLogSearch({ entries, version: 1, evictionCount: 0 }),
+    );
+
+    act(() => {
+      result.current.setIsRegex(true);
+      result.current.setQuery('.*');
+    });
+
+    expect(result.current.matches).toHaveLength(0);
+  });
+
+  it('handles query set while buffer is empty, then entries arrive', () => {
+    let entries: LogEntry[] = [];
+    let version = 1;
+
+    const { result, rerender } = renderHook(() =>
+      useLogSearch({ entries, version, evictionCount: 0 }),
+    );
+
+    act(() => result.current.setQuery('hello'));
+    expect(result.current.matches).toHaveLength(0);
+
+    // Entries arrive (new ref since we go from empty to populated)
+    entries = [entry('hello world'), entry('goodbye')];
+    version = 2;
+    rerender();
+
+    expect(result.current.matches).toHaveLength(1);
+    expect(result.current.matches[0].lineIndex).toBe(0);
+  });
+
+  it('clearing query after having matches resets everything', () => {
+    const entries = [entry('foo'), entry('foo')];
+    const { result } = renderHook(() =>
+      useLogSearch({ entries, version: 1, evictionCount: 0 }),
+    );
+
+    act(() => result.current.setQuery('foo'));
+    expect(result.current.matches).toHaveLength(2);
+
+    act(() => result.current.setQuery(''));
+    expect(result.current.matches).toHaveLength(0);
+    expect(result.current.totalMatches).toBe(0);
+    expect(result.current.capped).toBe(false);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Match navigation
+  // ---------------------------------------------------------------------------
+
+  it('nextMatch wraps around', () => {
+    const entries = [entry('aaa'), entry('bbb'), entry('aaa')];
+    const { result } = renderHook(() =>
+      useLogSearch({ entries, version: 1, evictionCount: 0 }),
+    );
+
+    act(() => result.current.setQuery('aaa'));
+    expect(result.current.currentMatchIndex).toBe(0);
+
+    act(() => result.current.nextMatch());
+    expect(result.current.currentMatchIndex).toBe(1);
+
+    act(() => result.current.nextMatch());
+    expect(result.current.currentMatchIndex).toBe(0); // wrapped
+  });
+
+  it('prevMatch wraps around', () => {
+    const entries = [entry('aaa'), entry('bbb'), entry('aaa')];
+    const { result } = renderHook(() =>
+      useLogSearch({ entries, version: 1, evictionCount: 0 }),
+    );
+
+    act(() => result.current.setQuery('aaa'));
+    expect(result.current.currentMatchIndex).toBe(0);
+
+    act(() => result.current.prevMatch());
+    expect(result.current.currentMatchIndex).toBe(1); // wrapped to last
+
+    act(() => result.current.prevMatch());
+    expect(result.current.currentMatchIndex).toBe(0);
+  });
+
+  it('nextMatch/prevMatch are no-ops when no matches exist', () => {
+    const entries = [entry('foo')];
+    const { result } = renderHook(() =>
+      useLogSearch({ entries, version: 1, evictionCount: 0 }),
+    );
+
+    act(() => result.current.setQuery('zzz'));
+    expect(result.current.currentMatchIndex).toBe(0);
+
+    act(() => result.current.nextMatch());
+    expect(result.current.currentMatchIndex).toBe(0);
+
+    act(() => result.current.prevMatch());
+    expect(result.current.currentMatchIndex).toBe(0);
+  });
+
+  it('currentMatchIndex clamps when matches shrink below it', () => {
+    const entries = [entry('aaa'), entry('aaa'), entry('aaa')];
+    const { result } = renderHook(() =>
+      useLogSearch({ entries, version: 1, evictionCount: 0 }),
+    );
+
+    act(() => result.current.setQuery('aaa'));
+    // Navigate to last match
+    act(() => result.current.nextMatch());
+    act(() => result.current.nextMatch());
+    expect(result.current.currentMatchIndex).toBe(2);
+
+    // Change query to something with fewer matches — resets index to 0
+    act(() => result.current.setQuery('aab'));
+    expect(result.current.currentMatchIndex).toBe(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Rapid sequential updates
+  // ---------------------------------------------------------------------------
+
+  it('handles multiple appends before asserting (RAF coalescing scenario)', () => {
+    const entries: LogEntry[] = [entry('match 1')];
+    let version = 1;
+
+    const { result, rerender } = renderHook(() =>
+      useLogSearch({ entries, version, evictionCount: 0 }),
+    );
+
+    act(() => result.current.setQuery('match'));
+    expect(result.current.matches).toHaveLength(1);
+
+    // Simulate multiple appends coalesced into one version bump
+    entries.push(entry('match 2'), entry('no'), entry('match 3'));
+    version = 2;
+    rerender();
+
+    expect(result.current.matches).toHaveLength(3);
+    expect(result.current.matches[1].lineIndex).toBe(1);
+    expect(result.current.matches[2].lineIndex).toBe(3);
+  });
+
+  it('does not reset match index on eviction-triggered full re-search', () => {
+    // Eviction triggers full re-search but should NOT reset currentMatchIndex
+    // (only query/regex/case changes should reset it)
+    let entries = [entry('foo a'), entry('foo b'), entry('foo c')];
+    let version = 1;
+    let evictionCount = 0;
+
+    const { result, rerender } = renderHook(() =>
+      useLogSearch({ entries, version, evictionCount }),
+    );
+
+    act(() => result.current.setQuery('foo'));
+    act(() => result.current.nextMatch());
+    expect(result.current.currentMatchIndex).toBe(1);
+
+    // Evict — same matches but re-searched
+    entries = [entry('foo a'), entry('foo b'), entry('foo c')];
+    version = 2;
+    evictionCount = 1;
+    rerender();
+
+    // Index is preserved (eviction doesn't reset it)
+    expect(result.current.currentMatchIndex).toBe(1);
+    expect(result.current.matches).toHaveLength(3);
+  });
+});

--- a/ui/providers/BottomDrawer/containers/LogViewer/hooks/useLogSearch.ts
+++ b/ui/providers/BottomDrawer/containers/LogViewer/hooks/useLogSearch.ts
@@ -1,10 +1,11 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { LogEntry, SearchMatch } from '../types';
-import { compileSearchPattern, execSafeSearch } from '../utils/regexSafety';
+import { compileSearchPattern, execSafeSearchRange, MAX_MATCH_COUNT } from '../utils/regexSafety';
 
 interface UseLogSearchOpts {
   entries: LogEntry[];
   version: number;
+  evictionCount: number;
 }
 
 interface UseLogSearchResult {
@@ -23,31 +24,125 @@ interface UseLogSearchResult {
   capped: boolean;
 }
 
-export function useLogSearch({ entries, version }: UseLogSearchOpts): UseLogSearchResult {
+interface SearchResult {
+  matches: SearchMatch[];
+  capped: boolean;
+}
+
+const EMPTY_RESULT: SearchResult = { matches: [], capped: false };
+
+export function useLogSearch({ entries, version, evictionCount }: UseLogSearchOpts): UseLogSearchResult {
   const [query, setQuery] = useState('');
   const [isRegex, setIsRegex] = useState(false);
   const [caseSensitive, setCaseSensitive] = useState(false);
   const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
+  const [searchResult, setSearchResult] = useState<SearchResult>(EMPTY_RESULT);
 
-  const searchResult = useMemo(() => {
-    const empty = { matches: [] as SearchMatch[], capped: false };
+  // Refs for tracking previous state to decide full vs incremental search
+  const prevQueryRef = useRef('');
+  const prevIsRegexRef = useRef(false);
+  const prevCaseSensitiveRef = useRef(false);
+  const prevEvictionCountRef = useRef(0);
+  const prevEntriesRef = useRef<LogEntry[]>(entries);
+  const prevSearchedLengthRef = useRef(0);
+  const prevCappedRef = useRef(false);
+  const prevMatchesRef = useRef<SearchMatch[]>([]);
 
+  useEffect(() => {
     const pattern = compileSearchPattern(query, { isRegex, caseSensitive });
-    if (!pattern) return empty;
+    if (!pattern) {
+      // Reset everything
+      prevQueryRef.current = query;
+      prevIsRegexRef.current = isRegex;
+      prevCaseSensitiveRef.current = caseSensitive;
+      prevEvictionCountRef.current = evictionCount;
+      prevEntriesRef.current = entries;
+      prevSearchedLengthRef.current = 0;
+      prevCappedRef.current = false;
+      prevMatchesRef.current = [];
+      setSearchResult(EMPTY_RESULT);
+      return;
+    }
 
-    const { results, capped } = execSafeSearch(
-      pattern,
-      entries.length,
-      (i) => entries[i].content,
-      (lineIndex, start, end) => ({
+    const searchParamsChanged =
+      query !== prevQueryRef.current ||
+      isRegex !== prevIsRegexRef.current ||
+      caseSensitive !== prevCaseSensitiveRef.current;
+    const evicted = evictionCount !== prevEvictionCountRef.current;
+    const entriesRefChanged = entries !== prevEntriesRef.current;
+    const entriesShrunk = entries.length < prevSearchedLengthRef.current;
+
+    const needsFullSearch =
+      searchParamsChanged || evicted || entriesRefChanged || entriesShrunk;
+
+    let result: SearchResult;
+
+    if (needsFullSearch) {
+      // Full re-search from scratch
+      const onMatch = (lineIndex: number, start: number, end: number): SearchMatch => ({
         lineIndex,
         startOffset: start,
         endOffset: end,
-      }),
-    );
+      });
 
-    return { matches: results, capped };
-  }, [query, isRegex, caseSensitive, entries, version]);
+      const { results, capped } = execSafeSearchRange(
+        pattern,
+        0,
+        entries.length,
+        (i) => entries[i].content,
+        onMatch,
+      );
+
+      result = { matches: results, capped };
+
+      if (searchParamsChanged) {
+        setCurrentMatchIndex(0);
+      }
+    } else if (prevCappedRef.current) {
+      // Already capped — skip searching new entries
+      result = { matches: prevMatchesRef.current, capped: true };
+    } else if (entries.length > prevSearchedLengthRef.current) {
+      // Incremental: search only new entries [prevLength, currentLength)
+      const budget = MAX_MATCH_COUNT - prevMatchesRef.current.length;
+
+      const onMatch = (lineIndex: number, start: number, end: number): SearchMatch => ({
+        lineIndex,
+        startOffset: start,
+        endOffset: end,
+      });
+
+      const { results: newMatches, capped } = execSafeSearchRange(
+        pattern,
+        prevSearchedLengthRef.current,
+        entries.length,
+        (i) => entries[i].content,
+        onMatch,
+        budget,
+      );
+
+      if (newMatches.length > 0) {
+        const combined = [...prevMatchesRef.current, ...newMatches];
+        result = { matches: combined, capped };
+      } else {
+        result = { matches: prevMatchesRef.current, capped };
+      }
+    } else {
+      // No change needed
+      result = { matches: prevMatchesRef.current, capped: prevCappedRef.current };
+    }
+
+    // Update all tracking refs
+    prevQueryRef.current = query;
+    prevIsRegexRef.current = isRegex;
+    prevCaseSensitiveRef.current = caseSensitive;
+    prevEvictionCountRef.current = evictionCount;
+    prevEntriesRef.current = entries;
+    prevSearchedLengthRef.current = entries.length;
+    prevCappedRef.current = result.capped;
+    prevMatchesRef.current = result.matches;
+
+    setSearchResult(result);
+  }, [query, isRegex, caseSensitive, version, evictionCount, entries]);
 
   const { matches, capped } = searchResult;
 

--- a/ui/providers/BottomDrawer/containers/LogViewer/index.tsx
+++ b/ui/providers/BottomDrawer/containers/LogViewer/index.tsx
@@ -38,7 +38,7 @@ const LogViewerContainer: React.FC<Props> = ({ sessionId }) => {
   // Track programmatic scrolls so scroll handler doesn't disengage follow
   const isAutoScrolling = useRef(false);
 
-  const { entries, version, append, clear: clearBuffer, lineCount } = useLogBuffer();
+  const { entries, version, append, clear: clearBuffer, lineCount, evictionCount } = useLogBuffer();
 
   const handleClear = useCallback(() => {
     clearBuffer();
@@ -55,7 +55,7 @@ const LogViewerContainer: React.FC<Props> = ({ sessionId }) => {
 
   const filteredLineCount = filteredEntries.length;
 
-  const search = useLogSearch({ entries: filteredEntries, version });
+  const search = useLogSearch({ entries: filteredEntries, version, evictionCount });
 
   const handleLines = useCallback(
     (newEntries: LogEntry[]) => {

--- a/ui/providers/BottomDrawer/containers/LogViewer/utils/regexSafety.bench.ts
+++ b/ui/providers/BottomDrawer/containers/LogViewer/utils/regexSafety.bench.ts
@@ -1,0 +1,191 @@
+import { bench, describe } from 'vitest';
+import {
+  compileSearchPattern,
+  execSafeSearch,
+  execSafeSearchRange,
+} from './regexSafety';
+
+// ---------------------------------------------------------------------------
+// Test data — representative of real Kubernetes / application log lines
+// ---------------------------------------------------------------------------
+
+const PLAIN_LOG = '2024-01-15T10:30:00.123Z INFO  [request_id=abc-123] GET /api/v1/namespaces/kube-system/pods responded 200 in 12.34ms';
+const ERROR_LOG = '2024-01-15T10:30:00.456Z ERROR [controller/deployment] failed to reconcile deployment/nginx-ingress in namespace kube-system: connection refused (retries=3)';
+const JSON_LOG = '{"timestamp":"2024-01-15T10:30:00Z","level":"warn","msg":"pod evicted","namespace":"default","pod":"worker-7f8b9c","reason":"NodeNotReady","node":"ip-10-0-1-42"}';
+
+// Build line arrays of various sizes
+function buildLines(count: number): string[] {
+  const templates = [PLAIN_LOG, ERROR_LOG, JSON_LOG];
+  return Array.from({ length: count }, (_, i) => templates[i % templates.length]);
+}
+
+const LINES_100 = buildLines(100);
+const LINES_1K = buildLines(1_000);
+const LINES_10K = buildLines(10_000);
+const LINES_100K = buildLines(100_000);
+
+// Precompiled patterns
+const LITERAL_PATTERN = compileSearchPattern('error', { isRegex: false, caseSensitive: false })!;
+const LITERAL_CASE_PATTERN = compileSearchPattern('ERROR', { isRegex: false, caseSensitive: true })!;
+const REGEX_PATTERN = compileSearchPattern('pod[s]?', { isRegex: true, caseSensitive: false })!;
+const COMPLEX_REGEX = compileSearchPattern('\\b\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\b', { isRegex: true, caseSensitive: false })!;
+const RARE_PATTERN = compileSearchPattern('NodeNotReady', { isRegex: false, caseSensitive: true })!;
+
+function buildMatch(lineIndex: number, start: number, end: number) {
+  return { lineIndex, start, end };
+}
+
+// ---------------------------------------------------------------------------
+// Pattern compilation
+// ---------------------------------------------------------------------------
+
+describe('compileSearchPattern', () => {
+  bench('literal string', () => {
+    compileSearchPattern('error', { isRegex: false, caseSensitive: false });
+  });
+
+  bench('literal string (case sensitive)', () => {
+    compileSearchPattern('ERROR', { isRegex: false, caseSensitive: true });
+  });
+
+  bench('regex pattern', () => {
+    compileSearchPattern('pod[s]?', { isRegex: true, caseSensitive: false });
+  });
+
+  bench('complex regex (IP address)', () => {
+    compileSearchPattern('\\b\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\b', { isRegex: true, caseSensitive: false });
+  });
+
+  bench('invalid regex (returns null)', () => {
+    compileSearchPattern('[unclosed', { isRegex: true, caseSensitive: false });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// execSafeSearch — full buffer scans
+// ---------------------------------------------------------------------------
+
+describe('execSafeSearch — full scan', () => {
+  describe('100 lines', () => {
+    bench('literal (case insensitive)', () => {
+      execSafeSearch(LITERAL_PATTERN, LINES_100.length, (i) => LINES_100[i], buildMatch);
+    });
+
+    bench('literal (case sensitive)', () => {
+      execSafeSearch(LITERAL_CASE_PATTERN, LINES_100.length, (i) => LINES_100[i], buildMatch);
+    });
+
+    bench('regex (pod[s]?)', () => {
+      execSafeSearch(REGEX_PATTERN, LINES_100.length, (i) => LINES_100[i], buildMatch);
+    });
+  });
+
+  describe('1k lines', () => {
+    bench('literal (case insensitive)', () => {
+      execSafeSearch(LITERAL_PATTERN, LINES_1K.length, (i) => LINES_1K[i], buildMatch);
+    });
+
+    bench('regex (pod[s]?)', () => {
+      execSafeSearch(REGEX_PATTERN, LINES_1K.length, (i) => LINES_1K[i], buildMatch);
+    });
+
+    bench('complex regex (IP address)', () => {
+      execSafeSearch(COMPLEX_REGEX, LINES_1K.length, (i) => LINES_1K[i], buildMatch);
+    });
+  });
+
+  describe('10k lines', () => {
+    bench('literal (case insensitive)', () => {
+      execSafeSearch(LITERAL_PATTERN, LINES_10K.length, (i) => LINES_10K[i], buildMatch);
+    });
+
+    bench('regex (pod[s]?)', () => {
+      execSafeSearch(REGEX_PATTERN, LINES_10K.length, (i) => LINES_10K[i], buildMatch);
+    });
+
+    bench('rare term (1 in 3 lines)', () => {
+      execSafeSearch(RARE_PATTERN, LINES_10K.length, (i) => LINES_10K[i], buildMatch);
+    });
+  });
+
+  describe('100k lines — full log buffer', () => {
+    bench('literal (case insensitive)', () => {
+      execSafeSearch(LITERAL_PATTERN, LINES_100K.length, (i) => LINES_100K[i], buildMatch);
+    }, { iterations: 3, warmupIterations: 1 });
+
+    bench('rare term', () => {
+      execSafeSearch(RARE_PATTERN, LINES_100K.length, (i) => LINES_100K[i], buildMatch);
+    }, { iterations: 3, warmupIterations: 1 });
+
+    bench('complex regex (IP address)', () => {
+      execSafeSearch(COMPLEX_REGEX, LINES_100K.length, (i) => LINES_100K[i], buildMatch);
+    }, { iterations: 3, warmupIterations: 1 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// execSafeSearchRange — incremental search (the hot path for live logs)
+// ---------------------------------------------------------------------------
+
+describe('execSafeSearchRange — incremental append', () => {
+  // Simulates the incremental search scenario: buffer already has N lines,
+  // search only the newly appended tail.
+
+  describe('append 10 lines to 10k buffer', () => {
+    bench('literal', () => {
+      execSafeSearchRange(LITERAL_PATTERN, 10_000 - 10, 10_000, (i) => LINES_10K[i], buildMatch);
+    });
+
+    bench('regex (pod[s]?)', () => {
+      execSafeSearchRange(REGEX_PATTERN, 10_000 - 10, 10_000, (i) => LINES_10K[i], buildMatch);
+    });
+  });
+
+  describe('append 100 lines to 100k buffer', () => {
+    bench('literal', () => {
+      execSafeSearchRange(LITERAL_PATTERN, 100_000 - 100, 100_000, (i) => LINES_100K[i], buildMatch);
+    });
+
+    bench('regex (pod[s]?)', () => {
+      execSafeSearchRange(REGEX_PATTERN, 100_000 - 100, 100_000, (i) => LINES_100K[i], buildMatch);
+    });
+
+    bench('complex regex (IP address)', () => {
+      execSafeSearchRange(COMPLEX_REGEX, 100_000 - 100, 100_000, (i) => LINES_100K[i], buildMatch);
+    });
+  });
+
+  describe('append 1k lines to 100k buffer', () => {
+    bench('literal', () => {
+      execSafeSearchRange(LITERAL_PATTERN, 100_000 - 1_000, 100_000, (i) => LINES_100K[i], buildMatch);
+    });
+
+    bench('complex regex (IP address)', () => {
+      execSafeSearchRange(COMPLEX_REGEX, 100_000 - 1_000, 100_000, (i) => LINES_100K[i], buildMatch);
+    });
+  });
+
+  describe('incremental with custom matchBudget', () => {
+    bench('budget=100 on 1k lines', () => {
+      execSafeSearchRange(LITERAL_PATTERN, 0, 1_000, (i) => LINES_1K[i], buildMatch, 100);
+    });
+
+    bench('budget=10 on 1k lines (early bail)', () => {
+      execSafeSearchRange(LITERAL_PATTERN, 0, 1_000, (i) => LINES_1K[i], buildMatch, 10);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Full vs incremental comparison
+// ---------------------------------------------------------------------------
+
+describe('full scan vs incremental — 100k buffer, 100 new lines', () => {
+  bench('FULL: re-scan all 100k lines', () => {
+    execSafeSearch(LITERAL_PATTERN, LINES_100K.length, (i) => LINES_100K[i], buildMatch);
+  }, { iterations: 3, warmupIterations: 1 });
+
+  bench('INCREMENTAL: scan only last 100 lines', () => {
+    execSafeSearchRange(LITERAL_PATTERN, 100_000 - 100, 100_000, (i) => LINES_100K[i], buildMatch);
+  }, { iterations: 3, warmupIterations: 1 });
+});


### PR DESCRIPTION
Replace useMemo-based search with incremental useEffect + useRef approach that tracks previous search state and only scans new entries when the buffer grows. Full re-search is triggered only when search params change, buffer eviction occurs, or the entries reference changes (e.g. source filter toggle).

Key changes:
- Add execSafeSearchRange() to search a [start, end) subrange with a configurable match budget; refactor execSafeSearch to delegate to it
- Add evictionCount to useLogBuffer to signal when cached match indices are invalidated by head-splice or clear
- Rewrite useLogSearch with incremental logic: append-only search for new entries, full re-search only when necessary

Performance: incremental search of 100 new lines into a 100k buffer is 333x faster than a full re-scan (~4.6μs vs ~1.5ms). Benchmarks added for pattern compilation, full scans at various buffer sizes, incremental appends, and match budget early-bail behavior.

Test coverage: 100% statements/branches/functions/lines across both regexSafety.ts and useLogSearch.ts (49 unit tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved log search performance through incremental matching and result capping for faster, more responsive searches when handling large log buffers.

* **Tests**
  * Added comprehensive test coverage and performance benchmarks for log search functionality and safety utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->