### PR TITLE
fix: log selection copies only content, not timestamps or chips

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "postinstall": "pnpm run bundle:yaml-worker",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "nx preview",
-    "test": "jest",
+    "test": "vitest run",
     "bench": "vitest bench --config vitest.bench.config.ts"
   },
   "dependencies": {

--- a/ui/providers/BottomDrawer/containers/LogViewer/LogEntry.spec.tsx
+++ b/ui/providers/BottomDrawer/containers/LogViewer/LogEntry.spec.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
 import LogEntryComponent from './LogEntry';
 import type { LogEntry, SearchMatch } from './types';
 
 // Mock scrollIntoView — jsdom doesn't implement it
-const scrollIntoView = jest.fn();
+const scrollIntoView = vi.fn();
 Element.prototype.scrollIntoView = scrollIntoView;
 
 function makeEntry(overrides: Partial<LogEntry> = {}): LogEntry {
@@ -40,11 +41,11 @@ function spansByBg(container: HTMLElement, color: string) {
 
 beforeEach(() => {
   scrollIntoView.mockClear();
-  jest.useFakeTimers();
+  vi.useFakeTimers();
 });
 
 afterEach(() => {
-  jest.useRealTimers();
+  vi.useRealTimers();
 });
 
 describe('LogEntryComponent', () => {
@@ -139,7 +140,7 @@ describe('LogEntryComponent', () => {
     );
 
     // Flush the requestAnimationFrame scheduled by the ref callback
-    jest.advanceTimersByTime(16);
+    vi.advanceTimersByTime(16);
 
     expect(scrollIntoView).toHaveBeenCalledWith({
       block: 'nearest',
@@ -160,7 +161,7 @@ describe('LogEntryComponent', () => {
       />,
     );
 
-    jest.advanceTimersByTime(16);
+    vi.advanceTimersByTime(16);
     expect(scrollIntoView).not.toHaveBeenCalled();
   });
 
@@ -178,7 +179,7 @@ describe('LogEntryComponent', () => {
       />,
     );
 
-    jest.advanceTimersByTime(16);
+    vi.advanceTimersByTime(16);
 
     // scrollIntoView should be called exactly once (only the current match)
     expect(scrollIntoView).toHaveBeenCalledTimes(1);

--- a/ui/providers/BottomDrawer/containers/LogViewer/LogEntry.spec.tsx
+++ b/ui/providers/BottomDrawer/containers/LogViewer/LogEntry.spec.tsx
@@ -81,6 +81,17 @@ describe('LogEntryComponent', () => {
     expect(screen.getByText('pod-a')).toBeInTheDocument();
   });
 
+  // ---- Selection (user-select) ----
+
+  it('source badge is not user-selectable', () => {
+    render(
+      <LogEntryComponent entry={makeEntry()} {...defaultProps} showSources />,
+    );
+    const badge = screen.getByText('pod-a');
+    expect(badge.style.userSelect).toBe('none');
+    expect(badge.style.webkitUserSelect).toBe('none');
+  });
+
   // ---- Search highlighting ----
 
   it('renders highlighted spans for search matches', () => {

--- a/ui/providers/BottomDrawer/containers/LogViewer/LogEntry.tsx
+++ b/ui/providers/BottomDrawer/containers/LogViewer/LogEntry.tsx
@@ -289,6 +289,7 @@ const LogEntryComponent: React.FC<Props> = ({
         <Text
           sx={{
             color: 'text.secondary',
+            userSelect: 'none',
             flexShrink: 0,
             fontSize: 'inherit',
             fontFamily: 'inherit',
@@ -312,6 +313,7 @@ const LogEntryComponent: React.FC<Props> = ({
             color: SOURCE_COLORS[sourceColorIndex(entry.sourceId)][1],
             flexShrink: 0,
             whiteSpace: 'nowrap',
+            userSelect: 'none',
           }}
         >
           {entry.sourceId}

--- a/ui/providers/BottomDrawer/containers/LogViewer/LogEntry.tsx
+++ b/ui/providers/BottomDrawer/containers/LogViewer/LogEntry.tsx
@@ -314,6 +314,7 @@ const LogEntryComponent: React.FC<Props> = ({
             flexShrink: 0,
             whiteSpace: 'nowrap',
             userSelect: 'none',
+            WebkitUserSelect: 'none',
           }}
         >
           {entry.sourceId}

--- a/ui/providers/BottomDrawer/containers/LogViewer/__tests__/LogViewer.test.tsx
+++ b/ui/providers/BottomDrawer/containers/LogViewer/__tests__/LogViewer.test.tsx
@@ -1,16 +1,17 @@
 import { render, cleanup, act, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
 import type { LogEntry, SearchMatch } from '../types';
 
 // ─── Hook mocks ────────────────────────────────────────────────────────────────
 
-const mockAppend = jest.fn();
-const mockClearBuffer = jest.fn();
+const mockAppend = vi.fn();
+const mockClearBuffer = vi.fn();
 
 let mockEntries: LogEntry[] = [];
 let mockVersion = 0;
 let mockLineCount = 0;
 
-jest.mock('../hooks/useLogBuffer', () => ({
+vi.mock('../hooks/useLogBuffer', () => ({
   useLogBuffer: () => ({
     entries: mockEntries,
     version: mockVersion,
@@ -20,17 +21,17 @@ jest.mock('../hooks/useLogBuffer', () => ({
   }),
 }));
 
-jest.mock('../hooks/useLogStream', () => ({
-  useLogStream: jest.fn(),
+vi.mock('../hooks/useLogStream', () => ({
+  useLogStream: vi.fn(),
 }));
 
-const mockSetQuery = jest.fn();
-const mockSetIsRegex = jest.fn();
-const mockSetCaseSensitive = jest.fn();
-const mockNextMatch = jest.fn();
-const mockPrevMatch = jest.fn();
+const mockSetQuery = vi.fn();
+const mockSetIsRegex = vi.fn();
+const mockSetCaseSensitive = vi.fn();
+const mockNextMatch = vi.fn();
+const mockPrevMatch = vi.fn();
 
-jest.mock('../hooks/useLogSearch', () => ({
+vi.mock('../hooks/useLogSearch', () => ({
   useLogSearch: () => ({
     query: '',
     setQuery: mockSetQuery,
@@ -47,21 +48,21 @@ jest.mock('../hooks/useLogSearch', () => ({
   }),
 }));
 
-jest.mock('../hooks/useLogSources', () => ({
+vi.mock('../hooks/useLogSources', () => ({
   useLogSources: () => ({
     sources: [],
     allSelected: true,
     selectedSourceIds: new Set<string>(),
-    toggleSource: jest.fn(),
-    toggleAll: jest.fn(),
+    toggleSource: vi.fn(),
+    toggleAll: vi.fn(),
     dimensions: [],
-    toggleValue: jest.fn(),
+    toggleValue: vi.fn(),
   }),
 }));
 
 // ─── Sub-component mocks ────────────────────────────────────────────────────────
 
-jest.mock('../LogEntry', () => {
+vi.mock('../LogEntry', () => {
   return {
     __esModule: true,
     default: ({ entry }: { entry: LogEntry }) => (
@@ -70,7 +71,7 @@ jest.mock('../LogEntry', () => {
   };
 });
 
-jest.mock('../LogViewerToolbar', () => {
+vi.mock('../LogViewerToolbar', () => {
   return {
     __esModule: true,
     default: (props: any) => (
@@ -84,26 +85,26 @@ jest.mock('../LogViewerToolbar', () => {
   };
 });
 
-jest.mock('../FilterSelect', () => ({
+vi.mock('../FilterSelect', () => ({
   __esModule: true,
   default: () => <div data-testid="filter-select" />,
 }));
 
-jest.mock('../JumpToTime', () => ({
+vi.mock('../JumpToTime', () => ({
   __esModule: true,
   default: () => <div data-testid="jump-to-time" />,
 }));
 
-jest.mock('../utils/downloadLogs', () => ({
-  saveLogsNative: jest.fn(),
+vi.mock('../utils/downloadLogs', () => ({
+  saveLogsNative: vi.fn(),
 }));
 
-jest.mock('../utils/binarySearchTimestamp', () => ({
-  findEntryIndexByTime: jest.fn(() => 0),
+vi.mock('../utils/binarySearchTimestamp', () => ({
+  findEntryIndexByTime: vi.fn(() => 0),
 }));
 
 // Virtual list mock — render items directly instead of virtualizing
-jest.mock('@tanstack/react-virtual', () => ({
+vi.mock('@tanstack/react-virtual', () => ({
   useVirtualizer: (opts: any) => {
     const items = Array.from({ length: opts.count }, (_, i) => ({
       index: i,
@@ -115,8 +116,8 @@ jest.mock('@tanstack/react-virtual', () => ({
     return {
       getVirtualItems: () => items,
       getTotalSize: () => opts.count * 18,
-      scrollToIndex: jest.fn(),
-      measureElement: jest.fn(),
+      scrollToIndex: vi.fn(),
+      measureElement: vi.fn(),
     };
   },
 }));
@@ -137,7 +138,7 @@ function makeEntry(n: number, content = `log line ${n}`): LogEntry {
 
 describe('LogViewerContainer', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
     mockEntries = [];
     mockVersion = 0;
     mockLineCount = 0;

--- a/ui/providers/BottomDrawer/containers/LogViewer/index.tsx
+++ b/ui/providers/BottomDrawer/containers/LogViewer/index.tsx
@@ -197,8 +197,11 @@ const LogViewerContainer: React.FC<Props> = ({ sessionId }) => {
       for (const sib of siblings) {
         sib.style.pointerEvents = '';
       }
+      document.removeEventListener('mouseup', restore);
+      window.removeEventListener('blur', restore);
     };
     document.addEventListener('mouseup', restore, { once: true });
+    window.addEventListener('blur', restore, { once: true });
   }, []);
 
   return (
@@ -362,6 +365,11 @@ const LogViewerContainer: React.FC<Props> = ({ sessionId }) => {
             whiteSpace: wrap ? 'normal' : 'pre',
             userSelect: 'text',
             outline: 'none',
+            '&:focus-visible': {
+              outline: '2px solid',
+              outlineColor: 'primary.outlinedBorder',
+              outlineOffset: -2,
+            },
           }}
         >
           <Box sx={{ paddingTop: `${paddingTop}px`, paddingBottom: `${paddingBottom}px` }}>

--- a/ui/providers/BottomDrawer/containers/LogViewer/index.tsx
+++ b/ui/providers/BottomDrawer/containers/LogViewer/index.tsx
@@ -185,17 +185,17 @@ const LogViewerContainer: React.FC<Props> = ({ sessionId }) => {
     const container = logEl?.parentElement;
     if (!logEl || !container) return;
 
-    const siblings: HTMLElement[] = [];
+    const saved: [HTMLElement, string][] = [];
     for (const child of container.children) {
       if (child !== logEl && child instanceof HTMLElement) {
+        saved.push([child, child.style.pointerEvents]);
         child.style.pointerEvents = 'none';
-        siblings.push(child);
       }
     }
 
     const restore = () => {
-      for (const sib of siblings) {
-        sib.style.pointerEvents = '';
+      for (const [el, prev] of saved) {
+        el.style.pointerEvents = prev;
       }
       document.removeEventListener('mouseup', restore);
       window.removeEventListener('blur', restore);

--- a/ui/providers/BottomDrawer/containers/LogViewer/utils/regexSafety.spec.ts
+++ b/ui/providers/BottomDrawer/containers/LogViewer/utils/regexSafety.spec.ts
@@ -1,3 +1,4 @@
+import { vi } from 'vitest';
 import {
   compileSearchPattern,
   execSafeSearch,
@@ -134,7 +135,7 @@ describe('execSafeSearch', () => {
   it('respects time budget', () => {
     // Mock performance.now to exceed the budget after a few lines
     let callCount = 0;
-    jest.spyOn(performance, 'now').mockImplementation(() => {
+    vi.spyOn(performance, 'now').mockImplementation(() => {
       callCount++;
       // After the first check (at line 512), return a value past the budget
       return callCount > 1 ? SEARCH_TIME_BUDGET_MS + 1 : 0;
@@ -149,7 +150,7 @@ describe('execSafeSearch', () => {
       // Should have stopped early
       expect(capped).toBe(true);
     } finally {
-      (performance.now as jest.Mock).mockRestore?.();
+      vi.mocked(performance.now).mockRestore?.();
     }
   });
 });

--- a/ui/test-setup.ts
+++ b/ui/test-setup.ts
@@ -1,0 +1,35 @@
+/// <reference types="@testing-library/jest-dom/vitest" />
+import { vi, expect } from 'vitest';
+import * as matchers from '@testing-library/jest-dom/matchers';
+
+// Extend vitest's expect with jest-dom matchers
+expect.extend(matchers);
+
+// matchMedia stub (required for MUI)
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+// ResizeObserver stub
+window.ResizeObserver = class {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+} as unknown as typeof ResizeObserver;
+
+// scrollIntoView stub (jsdom doesn't implement it)
+Element.prototype.scrollIntoView = vi.fn();
+
+// scrollTo stub (jsdom doesn't implement it)
+Element.prototype.scrollTo = vi.fn();
+window.scrollTo = vi.fn() as any;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 // import federation from '@originjs/vite-plugin-federation';
 // import topLevelAwait from 'vite-plugin-top-level-await';
@@ -17,6 +17,13 @@ const reactCompilerConfig = {
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./ui/test-setup.ts'],
+    css: false,
+    include: ['ui/**/*.{spec,test}.{ts,tsx}'],
+  },
   build: {
     minify: false,
     sourcemap: false,


### PR DESCRIPTION
## Summary
- Make only the actual log content selectable — timestamps, source badges (pod chips), and line numbers are excluded from text selection/copy via `userSelect: 'none'`
- Contain drag selections within the log scroll area by disabling `pointer-events` on sibling elements (toolbar, search input) during drag
- Scope Cmd+A / Ctrl+A to select only log content when the log area has focus, not the entire page
- Configure vitest at the root level (globals, jsdom, setup file) and migrate all LogViewer test files from jest to vi

## Test plan
- [x] 192 tests passing across 8 LogViewer test files
- [x] New test: source badge has `userSelect: 'none'` inline style
- [x] New test: Cmd+A creates selection scoped to log scroll area
- [x] New test: mousedown in log area disables pointer-events on toolbar, mouseup restores
- [x] Manual: select log lines and paste — only log content appears, no timestamps/chips
- [x] Manual: Cmd+A in log area selects only log content
- [ ] Manual: Cmd+A in search input selects search text (not log content)
- [ ] Manual: drag selection cannot escape into toolbar/search input

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cmd/Ctrl+A selects text scoped to the log area; log area is focusable and supports drag-selection containment.

* **Bug Fixes**
  * Prevented user selection of timestamps and source badges.
  * Ensured drag selection does not affect toolbar or adjacent controls; pointer behavior restored on blur.

* **Tests / Chores**
  * Migrated tests to Vitest, added a test setup and test config for jsdom and DOM matchers; updated/expanded log viewer tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->