### PR TITLE
feat: add copy-to-clipboard actions and fix tooltips in log viewer

### DIFF
--- a/packages/omniviewdev-ui/src/buttons/IconButton.tsx
+++ b/packages/omniviewdev-ui/src/buttons/IconButton.tsx
@@ -20,7 +20,7 @@ export interface IconButtonProps {
   sx?: SxProps<Theme>;
 }
 
-export default function IconButton({
+const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(function IconButton({
   children,
   color = 'neutral',
   emphasis,
@@ -32,7 +32,7 @@ export default function IconButton({
   title,
   sx,
   ...rest
-}: IconButtonProps) {
+}, ref) {
   const muiColor = toMuiColor(color) as any;
   const muiSize = toMuiSize(size) as any;
 
@@ -54,6 +54,7 @@ export default function IconButton({
 
   return (
     <MuiIconButton
+      ref={ref}
       color={muiColor}
       size={muiSize}
       disabled={disabled || loading}
@@ -75,6 +76,8 @@ export default function IconButton({
       )}
     </MuiIconButton>
   );
-}
+});
 
 IconButton.displayName = 'IconButton';
+
+export default IconButton;

--- a/packages/omniviewdev-ui/src/overlays/Tooltip.tsx
+++ b/packages/omniviewdev-ui/src/overlays/Tooltip.tsx
@@ -38,7 +38,7 @@ export default function Tooltip({
     ) : variant === 'rich' ? (
       <Box sx={{ p: 1, maxWidth: 320 }}>{resolvedTitle}</Box>
     ) : (
-      title
+      resolvedTitle
     );
 
   return (

--- a/ui/providers/BottomDrawer/containers/LogViewer/LogViewerToolbar.tsx
+++ b/ui/providers/BottomDrawer/containers/LogViewer/LogViewerToolbar.tsx
@@ -314,6 +314,7 @@ const LogViewerToolbar: React.FC<Props> = ({
           emphasis={copyFeedback === 'visible' ? 'soft' : 'ghost'}
           color={copyFeedback === 'visible' ? 'success' : 'neutral'}
           onClick={onCopyVisible}
+          aria-label="Copy visible lines"
         >
           {copyFeedback === 'visible' ? <LuClipboardCheck size={14} /> : <LuCopy size={14} />}
         </IconButton>
@@ -325,6 +326,7 @@ const LogViewerToolbar: React.FC<Props> = ({
           emphasis={copyFeedback === 'all' ? 'soft' : 'ghost'}
           color={copyFeedback === 'all' ? 'success' : 'neutral'}
           onClick={onCopyAll}
+          aria-label="Copy all lines"
         >
           {copyFeedback === 'all' ? <LuClipboardCheck size={14} /> : <LuClipboard size={14} />}
         </IconButton>

--- a/ui/providers/BottomDrawer/containers/LogViewer/LogViewerToolbar.tsx
+++ b/ui/providers/BottomDrawer/containers/LogViewer/LogViewerToolbar.tsx
@@ -127,7 +127,7 @@ const LogViewerToolbar: React.FC<Props> = ({
   jumpToTime,
   lineCount,
 }) => {
-  const isMac = /mac/i.test(navigator.userAgent);
+  const isMac = typeof navigator !== 'undefined' && /mac/i.test(navigator.userAgent);
   const prevHold = useHoldRepeat(onPrevMatch);
   const nextHold = useHoldRepeat(onNextMatch);
 

--- a/ui/providers/BottomDrawer/containers/LogViewer/LogViewerToolbar.tsx
+++ b/ui/providers/BottomDrawer/containers/LogViewer/LogViewerToolbar.tsx
@@ -22,6 +22,9 @@ import {
   LuPlay,
   LuPalette,
   LuX,
+  LuCopy,
+  LuClipboardCheck,
+  LuClipboard,
 } from 'react-icons/lu';
 
 /** Fires `action` on click, then repeats while held (accelerating). */
@@ -74,6 +77,9 @@ interface Props {
   onToggleFollow: () => void;
   paused: boolean;
   onTogglePaused: () => void;
+  onCopyVisible: () => void;
+  onCopyAll: () => void;
+  copyFeedback: 'visible' | 'all' | null;
   onDownload: () => void;
   onClear: () => void;
 
@@ -112,12 +118,16 @@ const LogViewerToolbar: React.FC<Props> = ({
   onToggleFollow,
   paused,
   onTogglePaused,
+  onCopyVisible,
+  onCopyAll,
+  copyFeedback,
   onDownload,
   onClear,
   filterSelectors,
   jumpToTime,
   lineCount,
 }) => {
+  const isMac = /mac/i.test(navigator.userAgent);
   const prevHold = useHoldRepeat(onPrevMatch);
   const nextHold = useHoldRepeat(onNextMatch);
 
@@ -297,6 +307,28 @@ const LogViewerToolbar: React.FC<Props> = ({
       </Tooltip>
 
       <Divider orientation="vertical" sx={{ mx: 0.5 }} />
+
+      <Tooltip content={copyFeedback === 'visible' ? 'Copied!' : `Copy visible lines (${isMac ? '⌘⇧V' : 'Ctrl+Shift+V'})`}>
+        <IconButton
+          size="sm"
+          emphasis={copyFeedback === 'visible' ? 'soft' : 'ghost'}
+          color={copyFeedback === 'visible' ? 'success' : 'neutral'}
+          onClick={onCopyVisible}
+        >
+          {copyFeedback === 'visible' ? <LuClipboardCheck size={14} /> : <LuCopy size={14} />}
+        </IconButton>
+      </Tooltip>
+
+      <Tooltip content={copyFeedback === 'all' ? 'Copied!' : `Copy all lines (${isMac ? '⌘⇧C' : 'Ctrl+Shift+C'})`}>
+        <IconButton
+          size="sm"
+          emphasis={copyFeedback === 'all' ? 'soft' : 'ghost'}
+          color={copyFeedback === 'all' ? 'success' : 'neutral'}
+          onClick={onCopyAll}
+        >
+          {copyFeedback === 'all' ? <LuClipboardCheck size={14} /> : <LuClipboard size={14} />}
+        </IconButton>
+      </Tooltip>
 
       <Tooltip content="Download">
         <IconButton size="sm" emphasis="ghost" onClick={onDownload}>

--- a/ui/providers/BottomDrawer/containers/LogViewer/__tests__/LogViewer.test.tsx
+++ b/ui/providers/BottomDrawer/containers/LogViewer/__tests__/LogViewer.test.tsx
@@ -79,8 +79,8 @@ jest.mock('../LogViewerToolbar', () => {
         <button data-testid="toggle-wrap" onClick={props.onToggleWrap}>wrap</button>
         <button data-testid="toggle-follow" onClick={props.onToggleFollow}>follow</button>
         <button data-testid="toggle-paused" onClick={props.onTogglePaused}>pause</button>
-        <button data-testid="copy-visible" onClick={props.onCopyVisible}>copy visible</button>
-        <button data-testid="copy-all" onClick={props.onCopyAll}>copy all</button>
+        <button type="button" data-testid="copy-visible" onClick={props.onCopyVisible}>copy visible</button>
+        <button type="button" data-testid="copy-all" onClick={props.onCopyAll}>copy all</button>
       </div>
     ),
   };
@@ -121,7 +121,7 @@ jest.mock('@tanstack/react-virtual', () => ({
       getTotalSize: () => opts.count * 18,
       scrollToIndex: jest.fn(),
       measureElement: jest.fn(),
-      range: opts.count > 0 ? { startIndex: 0, endIndex: opts.count - 1 } : null,
+      range: opts.count > 2 ? { startIndex: 1, endIndex: 2 } : opts.count > 0 ? { startIndex: 0, endIndex: opts.count - 1 } : null,
     };
   },
 }));
@@ -237,9 +237,9 @@ describe('LogViewerContainer', () => {
   });
 
   it('copy visible copies only viewport entries to clipboard', async () => {
-    mockEntries = [makeEntry(0), makeEntry(1), makeEntry(2)];
+    mockEntries = [makeEntry(0), makeEntry(1), makeEntry(2), makeEntry(3)];
     mockVersion = 1;
-    mockLineCount = 3;
+    mockLineCount = 4;
 
     const { getByTestId } = render(<LogViewerContainer sessionId="sess-1" />);
 
@@ -247,8 +247,8 @@ describe('LogViewerContainer', () => {
       fireEvent.click(getByTestId('copy-visible'));
     });
 
-    // The virtualizer mock range is { startIndex: 0, endIndex: 2 } for 3 items
-    expect(mockCopyLogsToClipboard).toHaveBeenCalledWith(mockEntries);
+    // The virtualizer mock range is { startIndex: 1, endIndex: 2 } for count > 2
+    expect(mockCopyLogsToClipboard).toHaveBeenCalledWith([mockEntries[1], mockEntries[2]]);
   });
 
   it('Cmd+Shift+C triggers copy all', async () => {
@@ -262,7 +262,14 @@ describe('LogViewerContainer', () => {
     await act(async () => {
       fireEvent.keyDown(wrapper, { key: 'C', metaKey: true, shiftKey: true });
     });
+    expect(mockCopyLogsToClipboard).toHaveBeenCalledWith(mockEntries);
 
+    mockCopyLogsToClipboard.mockClear();
+
+    // Also works with Ctrl (Windows/Linux)
+    await act(async () => {
+      fireEvent.keyDown(wrapper, { key: 'C', ctrlKey: true, shiftKey: true });
+    });
     expect(mockCopyLogsToClipboard).toHaveBeenCalledWith(mockEntries);
   });
 
@@ -277,7 +284,14 @@ describe('LogViewerContainer', () => {
     await act(async () => {
       fireEvent.keyDown(wrapper, { key: 'V', metaKey: true, shiftKey: true });
     });
+    expect(mockCopyLogsToClipboard).toHaveBeenCalledWith(mockEntries);
 
+    mockCopyLogsToClipboard.mockClear();
+
+    // Also works with Ctrl (Windows/Linux)
+    await act(async () => {
+      fireEvent.keyDown(wrapper, { key: 'V', ctrlKey: true, shiftKey: true });
+    });
     expect(mockCopyLogsToClipboard).toHaveBeenCalledWith(mockEntries);
   });
 });

--- a/ui/providers/BottomDrawer/containers/LogViewer/__tests__/LogViewer.test.tsx
+++ b/ui/providers/BottomDrawer/containers/LogViewer/__tests__/LogViewer.test.tsx
@@ -296,6 +296,37 @@ describe('LogViewerContainer', () => {
     expect(mockCopyLogsToClipboard).toHaveBeenCalledWith(mockEntries);
   });
 
+  it('does not trigger copy shortcuts from editable elements', async () => {
+    mockEntries = [makeEntry(0), makeEntry(1)];
+    mockVersion = 1;
+    mockLineCount = 2;
+
+    const { container } = render(<LogViewerContainer sessionId="sess-1" />);
+    const wrapper = container.firstElementChild as HTMLElement;
+
+    // contentEditable div
+    const editable = document.createElement('div');
+    editable.contentEditable = 'true';
+    wrapper.appendChild(editable);
+    editable.focus();
+
+    mockCopyLogsToClipboard.mockClear();
+    await act(async () => {
+      fireEvent.keyDown(editable, { key: 'C', metaKey: true, shiftKey: true });
+    });
+    expect(mockCopyLogsToClipboard).not.toHaveBeenCalled();
+
+    // input element
+    const input = document.createElement('input');
+    wrapper.appendChild(input);
+    input.focus();
+
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'C', ctrlKey: true, shiftKey: true });
+    });
+    expect(mockCopyLogsToClipboard).not.toHaveBeenCalled();
+  });
+
   // ---- Selection containment ----
 
   it('Cmd+A selects only within the log scroll area', () => {

--- a/ui/providers/BottomDrawer/containers/LogViewer/index.tsx
+++ b/ui/providers/BottomDrawer/containers/LogViewer/index.tsx
@@ -54,6 +54,16 @@ const LogViewerContainer: React.FC<Props> = ({ sessionId }) => {
     copyFeedbackTimer.current = setTimeout(() => setCopyFeedback(null), 1500);
   }, []);
 
+  // Clean up feedback timer on unmount
+  React.useEffect(() => {
+    return () => {
+      if (copyFeedbackTimer.current) {
+        clearTimeout(copyFeedbackTimer.current);
+        copyFeedbackTimer.current = null;
+      }
+    };
+  }, []);
+
   // Source selection (multi-select filtering)
   const sourceState = useLogSources({ sessionId, events, entries, version });
 
@@ -156,6 +166,17 @@ const LogViewerContainer: React.FC<Props> = ({ sessionId }) => {
     (e: React.KeyboardEvent) => {
       const mod = e.metaKey || e.ctrlKey;
       if (!mod || !e.shiftKey) return;
+
+      // Don't intercept when typing in an input or editable area
+      const target = e.target as HTMLElement;
+      if (
+        target.isContentEditable ||
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.tagName === 'SELECT'
+      ) {
+        return;
+      }
 
       if (e.key === 'C' || e.key === 'c') {
         e.preventDefault();

--- a/ui/providers/BottomDrawer/containers/LogViewer/index.tsx
+++ b/ui/providers/BottomDrawer/containers/LogViewer/index.tsx
@@ -171,6 +171,7 @@ const LogViewerContainer: React.FC<Props> = ({ sessionId }) => {
       const target = e.target as HTMLElement;
       if (
         target.isContentEditable ||
+        target.contentEditable === 'true' ||
         target.tagName === 'INPUT' ||
         target.tagName === 'TEXTAREA' ||
         target.tagName === 'SELECT'
@@ -269,7 +270,7 @@ const LogViewerContainer: React.FC<Props> = ({ sessionId }) => {
 
   return (
     <Box
-      tabIndex={-1}
+      tabIndex={0}
       onKeyDown={handleKeyDown}
       sx={{
         display: 'flex',
@@ -280,6 +281,11 @@ const LogViewerContainer: React.FC<Props> = ({ sessionId }) => {
         position: 'relative',
         outline: 'none',
         userSelect: 'none',
+        '&:focus-visible': {
+          outline: '2px solid',
+          outlineColor: 'primary.outlinedBorder',
+          outlineOffset: -2,
+        },
       }}
     >
       <LogViewerToolbar

--- a/ui/providers/BottomDrawer/containers/LogViewer/utils/downloadLogs.ts
+++ b/ui/providers/BottomDrawer/containers/LogViewer/utils/downloadLogs.ts
@@ -1,7 +1,8 @@
 import { SaveFileDialog, WriteFileContent } from '@omniviewdev/runtime/api';
 import type { LogEntry } from '../types';
 
-function formatAsText(entries: LogEntry[]): string {
+/** Format entries as plain text lines. Exported for clipboard use. */
+export function formatAsText(entries: LogEntry[]): string {
   return entries.map((e) => {
     const ts = e.timestamp ? `[${e.timestamp}] ` : '';
     const src = e.sourceId ? `[${e.sourceId}] ` : '';
@@ -79,4 +80,15 @@ function downloadBlob(content: string, filename: string, mimeType: string): void
   a.download = filename;
   a.click();
   URL.revokeObjectURL(url);
+}
+
+/** Copy log entries as plain text to the system clipboard. Returns true on success. */
+export async function copyLogsToClipboard(entries: LogEntry[]): Promise<boolean> {
+  if (entries.length === 0) return false;
+  try {
+    await navigator.clipboard.writeText(formatAsText(entries));
+    return true;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
## Summary
- Add **copy visible lines** and **copy all lines** buttons to the log viewer toolbar
- Keyboard shortcuts: `Cmd/Ctrl+Shift+V` (visible) and `Cmd/Ctrl+Shift+C` (all)
- Brief visual feedback on copy success (green checkmark icon, 1.5s)
- Fix tooltips not appearing on any toolbar buttons by forwarding refs through `IconButton` and correcting `Tooltip` default variant to use `resolvedTitle`

## Test plan
- [x] Existing log viewer tests pass
- [x] New tests for copy-all button, copy-visible button, and both keyboard shortcuts
- [x] Verify tooltips appear on hover for all toolbar buttons in the app
- [ ] Verify copy visible/all buttons copy correct content to clipboard
- [ ] Verify keyboard shortcuts trigger visual feedback on the buttons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added copy-to-clipboard in the log viewer: "Copy visible" and "Copy all" toolbar buttons plus keyboard shortcuts (Cmd/Ctrl+Shift+V for visible, Cmd/Ctrl+Shift+C for all).

* **Improvements**
  * Icon button updated for improved focus/ref handling and more reliable keyboard interaction.
  * Toolbar shows per-action visual state when content is copied.

* **Bug Fixes**
  * Tooltips now consistently show the resolved title across variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->