### PR TITLE
feat: log viewer keyboard navigation shortcuts

### DIFF
--- a/ui/providers/BottomDrawer/containers/LogViewer/LogViewerToolbar.tsx
+++ b/ui/providers/BottomDrawer/containers/LogViewer/LogViewerToolbar.tsx
@@ -152,6 +152,7 @@ const LogViewerToolbar: React.FC<Props> = ({
         placeholder="Search in logs"
         autoFocus
         autoComplete="off"
+        inputProps={{ 'data-search-input': true }}
         value={searchQuery}
         onChange={(value) => onSearchChange(value)}
         startAdornment={<LuSearch size={14} />}

--- a/ui/providers/BottomDrawer/containers/LogViewer/__tests__/LogViewer.test.tsx
+++ b/ui/providers/BottomDrawer/containers/LogViewer/__tests__/LogViewer.test.tsx
@@ -78,7 +78,7 @@ vi.mock('../LogViewerToolbar', () => {
     __esModule: true,
     default: (props: any) => (
       <div data-testid="log-toolbar">
-        <input placeholder="Search in logs" data-testid="search-input" />
+        <input data-search-input data-testid="search-input" />
         <button data-testid="toggle-timestamps" onClick={props.onToggleTimestamps}>timestamps</button>
         <button data-testid="toggle-wrap" onClick={props.onToggleWrap}>wrap</button>
         <button data-testid="toggle-follow" onClick={props.onToggleFollow}>follow</button>

--- a/ui/providers/BottomDrawer/containers/LogViewer/__tests__/LogViewer.test.tsx
+++ b/ui/providers/BottomDrawer/containers/LogViewer/__tests__/LogViewer.test.tsx
@@ -30,6 +30,8 @@ const mockSetIsRegex = vi.fn();
 const mockSetCaseSensitive = vi.fn();
 const mockNextMatch = vi.fn();
 const mockPrevMatch = vi.fn();
+let mockSearchMatches: SearchMatch[] = [];
+let mockCurrentMatchIndex = 0;
 
 vi.mock('../hooks/useLogSearch', () => ({
   useLogSearch: () => ({
@@ -39,9 +41,9 @@ vi.mock('../hooks/useLogSearch', () => ({
     setIsRegex: mockSetIsRegex,
     caseSensitive: false,
     setCaseSensitive: mockSetCaseSensitive,
-    matches: [] as SearchMatch[],
-    totalMatches: 0,
-    currentMatchIndex: 0,
+    matches: mockSearchMatches,
+    totalMatches: mockSearchMatches.length,
+    currentMatchIndex: mockCurrentMatchIndex,
     capped: false,
     nextMatch: mockNextMatch,
     prevMatch: mockPrevMatch,
@@ -76,6 +78,7 @@ vi.mock('../LogViewerToolbar', () => {
     __esModule: true,
     default: (props: any) => (
       <div data-testid="log-toolbar">
+        <input placeholder="Search in logs" data-testid="search-input" />
         <button data-testid="toggle-timestamps" onClick={props.onToggleTimestamps}>timestamps</button>
         <button data-testid="toggle-wrap" onClick={props.onToggleWrap}>wrap</button>
         <button data-testid="toggle-follow" onClick={props.onToggleFollow}>follow</button>
@@ -147,6 +150,8 @@ describe('LogViewerContainer', () => {
     mockEntries = [];
     mockVersion = 0;
     mockLineCount = 0;
+    mockSearchMatches = [];
+    mockCurrentMatchIndex = 0;
   });
 
   afterEach(() => {
@@ -294,6 +299,122 @@ describe('LogViewerContainer', () => {
       fireEvent.keyDown(wrapper, { key: 'V', ctrlKey: true, shiftKey: true });
     });
     expect(mockCopyLogsToClipboard).toHaveBeenCalledWith(mockEntries);
+  });
+
+  it('Cmd+F focuses the search input (Mac)', () => {
+    mockEntries = [makeEntry(0)];
+    mockVersion = 1;
+    mockLineCount = 1;
+
+    const { container, getByTestId } = render(<LogViewerContainer sessionId="sess-1" />);
+    const wrapper = container.firstElementChild as HTMLElement;
+    const searchInput = getByTestId('search-input') as HTMLInputElement;
+
+    // Focus should not be on search input initially
+    expect(document.activeElement).not.toBe(searchInput);
+
+    fireEvent.keyDown(wrapper, { key: 'f', metaKey: true });
+
+    expect(document.activeElement).toBe(searchInput);
+  });
+
+  it('Ctrl+F focuses the search input (Windows/Linux)', () => {
+    mockEntries = [makeEntry(0)];
+    mockVersion = 1;
+    mockLineCount = 1;
+
+    const { container, getByTestId } = render(<LogViewerContainer sessionId="sess-1" />);
+    const wrapper = container.firstElementChild as HTMLElement;
+    const searchInput = getByTestId('search-input') as HTMLInputElement;
+
+    expect(document.activeElement).not.toBe(searchInput);
+
+    fireEvent.keyDown(wrapper, { key: 'F', ctrlKey: true });
+
+    expect(document.activeElement).toBe(searchInput);
+  });
+
+  it('Escape from search input returns focus to the scroll area', () => {
+    mockEntries = [makeEntry(0)];
+    mockVersion = 1;
+    mockLineCount = 1;
+
+    const { container, getByTestId } = render(<LogViewerContainer sessionId="sess-1" />);
+    const searchInput = getByTestId('search-input') as HTMLInputElement;
+    searchInput.focus();
+    expect(document.activeElement).toBe(searchInput);
+
+    fireEvent.keyDown(searchInput, { key: 'Escape' });
+
+    // Focus should move to the scroll area (tabindex=0 element inside the container)
+    const wrapper = container.firstElementChild as HTMLElement;
+    const scrollArea = wrapper.querySelector('[tabindex="0"]:not([data-testid="log-toolbar"] *)');
+    expect(document.activeElement).toBe(scrollArea);
+  });
+
+  it('Cmd+Shift+L copies the current match log line (Mac)', async () => {
+    mockEntries = [makeEntry(0), makeEntry(1, 'match line'), makeEntry(2)];
+    mockVersion = 1;
+    mockLineCount = 3;
+    mockSearchMatches = [{ lineIndex: 1, startOffset: 0, endOffset: 5 }];
+    mockCurrentMatchIndex = 0;
+
+    const { container } = render(<LogViewerContainer sessionId="sess-1" />);
+    const wrapper = container.firstElementChild as HTMLElement;
+
+    await act(async () => {
+      fireEvent.keyDown(wrapper, { key: 'L', metaKey: true, shiftKey: true });
+    });
+    expect(mockCopyLogsToClipboard).toHaveBeenCalledWith([mockEntries[1]]);
+  });
+
+  it('Ctrl+Shift+L copies the current match log line (Windows/Linux)', async () => {
+    mockEntries = [makeEntry(0), makeEntry(1, 'match line'), makeEntry(2)];
+    mockVersion = 1;
+    mockLineCount = 3;
+    mockSearchMatches = [{ lineIndex: 1, startOffset: 0, endOffset: 5 }];
+    mockCurrentMatchIndex = 0;
+
+    const { container } = render(<LogViewerContainer sessionId="sess-1" />);
+    const wrapper = container.firstElementChild as HTMLElement;
+
+    await act(async () => {
+      fireEvent.keyDown(wrapper, { key: 'l', ctrlKey: true, shiftKey: true });
+    });
+    expect(mockCopyLogsToClipboard).toHaveBeenCalledWith([mockEntries[1]]);
+  });
+
+  it('Cmd+Shift+L works from the search input', async () => {
+    mockEntries = [makeEntry(0), makeEntry(1, 'match line'), makeEntry(2)];
+    mockVersion = 1;
+    mockLineCount = 3;
+    mockSearchMatches = [{ lineIndex: 1, startOffset: 0, endOffset: 5 }];
+    mockCurrentMatchIndex = 0;
+
+    const { getByTestId } = render(<LogViewerContainer sessionId="sess-1" />);
+    const searchInput = getByTestId('search-input') as HTMLInputElement;
+    searchInput.focus();
+
+    await act(async () => {
+      fireEvent.keyDown(searchInput, { key: 'L', metaKey: true, shiftKey: true });
+    });
+    expect(mockCopyLogsToClipboard).toHaveBeenCalledWith([mockEntries[1]]);
+  });
+
+  it('Cmd+Shift+L does nothing when no search matches exist', async () => {
+    mockEntries = [makeEntry(0), makeEntry(1)];
+    mockVersion = 1;
+    mockLineCount = 2;
+    mockSearchMatches = [];
+
+    const { container } = render(<LogViewerContainer sessionId="sess-1" />);
+    const wrapper = container.firstElementChild as HTMLElement;
+
+    mockCopyLogsToClipboard.mockClear();
+    await act(async () => {
+      fireEvent.keyDown(wrapper, { key: 'L', metaKey: true, shiftKey: true });
+    });
+    expect(mockCopyLogsToClipboard).not.toHaveBeenCalled();
   });
 
   it('does not trigger copy shortcuts from editable elements', async () => {

--- a/ui/providers/BottomDrawer/containers/LogViewer/index.tsx
+++ b/ui/providers/BottomDrawer/containers/LogViewer/index.tsx
@@ -184,7 +184,10 @@ const LogViewerContainer: React.FC<Props> = ({ sessionId }) => {
   // Copy the log line at the current search match
   const handleCopyMatchLine = useCallback(async () => {
     if (search.matches.length === 0) return;
-    const match = search.matches[search.currentMatchIndex];
+    const idx = search.currentMatchIndex;
+    if (idx < 0 || idx >= search.matches.length) return;
+    const match = search.matches[idx];
+    if (!match) return;
     const entry = filteredEntries[match.lineIndex];
     if (!entry) return;
     const ok = await copyLogsToClipboard([entry]);
@@ -207,7 +210,7 @@ const LogViewerContainer: React.FC<Props> = ({ sessionId }) => {
       if (!e.shiftKey && (e.key === 'f' || e.key === 'F')) {
         e.preventDefault();
         const el = (e.currentTarget as HTMLElement).querySelector<HTMLInputElement>(
-          'input[placeholder="Search in logs"]',
+          'input[data-search-input]',
         );
         if (el) {
           el.focus();


### PR DESCRIPTION
## Summary
- **Cmd/Ctrl+F** focuses the search input (selects existing text)
- **Escape** from search returns focus to the scroll area
- **Cmd/Ctrl+Shift+L** copies the log line at the current search match with a green flash animation for visual feedback
- All shortcuts support Mac (metaKey) and Windows/Linux (ctrlKey) modifiers

## Test plan
- [x] 8 new tests covering all shortcuts on both Mac and Windows/Linux
- [x] Tests for edge cases: no matches, firing from search input
- [x] All 22 tests passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visual per-line flash animation when a log line is copied.
  * Keyboard shortcuts: Cmd/Ctrl+F to focus search, Escape to return focus to the log, Cmd/Ctrl+Shift+L to copy the current search match line, and Cmd/Ctrl+A to select within the log area.

* **Tests**
  * Expanded coverage for search focus, keyboard navigation, copy behavior (including from search input), and cases with/without matches; ensures copy shortcuts don’t trigger from editable elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->