### PR TITLE
fix: prevent bottom drawer from overflowing past viewport

### DIFF
--- a/ui/layouts/core/main/BottomDrawer/__tests__/BottomDrawer.test.tsx
+++ b/ui/layouts/core/main/BottomDrawer/__tests__/BottomDrawer.test.tsx
@@ -288,6 +288,57 @@ describe('BottomDrawerContainer', () => {
     expect(drawer.style.height).toBe('32px');
   });
 
+  it('minHeight stays at 32px floor when expanded', () => {
+    mockUseBottomDrawer.mockReturnValue({
+      tabs: [{ id: 'tab1', title: 'Term', variant: 'terminal', icon: 'LuTerminal' }],
+      focused: 0,
+    });
+
+    const { container } = render(<BottomDrawerContainer />);
+    const drawer = container.querySelector('.BottomDrawer') as HTMLElement;
+
+    // Expanded to 400px — minHeight should still be 32px (the floor)
+    expect(drawer.style.height).toBe('400px');
+    expect(drawer.style.minHeight).toBe('32px');
+    expect(drawer.style.maxHeight).toBe('400px');
+  });
+
+  it('minHeight stays at 32px floor when fullscreen', () => {
+    mockUseBottomDrawer.mockReturnValue({
+      tabs: [{ id: 'tab1', title: 'Term', variant: 'terminal', icon: 'LuTerminal' }],
+      focused: 0,
+    });
+
+    const { container, getByTestId } = render(<BottomDrawerContainer />);
+
+    act(() => {
+      fireEvent.click(getByTestId('btn-fullscreen'));
+    });
+
+    const drawer = container.querySelector('.BottomDrawer') as HTMLElement;
+    expect(drawer.style.height).toBe('900px');
+    expect(drawer.style.minHeight).toBe('32px');
+    expect(drawer.style.maxHeight).toBe('900px');
+  });
+
+  it('all height properties lock to 32px when minimized', () => {
+    mockUseBottomDrawer.mockReturnValue({
+      tabs: [{ id: 'tab1', title: 'Term', variant: 'terminal', icon: 'LuTerminal' }],
+      focused: 0,
+    });
+
+    const { container, getByTestId } = render(<BottomDrawerContainer />);
+
+    act(() => {
+      fireEvent.click(getByTestId('btn-minimize'));
+    });
+
+    const drawer = container.querySelector('.BottomDrawer') as HTMLElement;
+    expect(drawer.style.height).toBe('32px');
+    expect(drawer.style.minHeight).toBe('32px');
+    expect(drawer.style.maxHeight).toBe('32px');
+  });
+
   it('renders terminal container for terminal tab variant', () => {
     mockUseBottomDrawer.mockReturnValue({
       tabs: [{ id: 'sess-1', title: 'Term', variant: 'terminal', icon: 'LuTerminal' }],

--- a/ui/layouts/core/main/BottomDrawer/__tests__/BottomDrawer.test.tsx
+++ b/ui/layouts/core/main/BottomDrawer/__tests__/BottomDrawer.test.tsx
@@ -87,7 +87,7 @@ describe('BottomDrawerContainer', () => {
     const drawer = container.querySelector('.BottomDrawer') as HTMLElement;
     expect(drawer).toBeTruthy();
     // Initial state — minHeight should be 32px
-    expect(drawer.style.minHeight).toBe('32px');
+    expect(drawer.style.height).toBe('32px');
   });
 
   it('expands to defaultHeight when tabs appear', () => {
@@ -102,7 +102,7 @@ describe('BottomDrawerContainer', () => {
     rerender(<BottomDrawerContainer />);
 
     const drawer = container.querySelector('.BottomDrawer') as HTMLElement;
-    expect(drawer.style.minHeight).toBe('400px');
+    expect(drawer.style.height).toBe('400px');
   });
 
   it('minimize collapses to minHeight', () => {
@@ -119,7 +119,7 @@ describe('BottomDrawerContainer', () => {
     });
 
     const drawer = container.querySelector('.BottomDrawer') as HTMLElement;
-    expect(drawer.style.minHeight).toBe('32px');
+    expect(drawer.style.height).toBe('32px');
   });
 
   it('expand restores last expanded height', () => {
@@ -134,19 +134,19 @@ describe('BottomDrawerContainer', () => {
     rerender(<BottomDrawerContainer />);
 
     const drawer = container.querySelector('.BottomDrawer') as HTMLElement;
-    expect(drawer.style.minHeight).toBe('400px');
+    expect(drawer.style.height).toBe('400px');
 
     // Minimize
     act(() => {
       fireEvent.click(getByTestId('btn-minimize'));
     });
-    expect(drawer.style.minHeight).toBe('32px');
+    expect(drawer.style.height).toBe('32px');
 
     // Expand should restore to 400px
     act(() => {
       fireEvent.click(getByTestId('btn-expand'));
     });
-    expect(drawer.style.minHeight).toBe('400px');
+    expect(drawer.style.height).toBe('400px');
   });
 
   it('fullscreen sets height to window.innerHeight', () => {
@@ -162,7 +162,7 @@ describe('BottomDrawerContainer', () => {
     });
 
     const drawer = container.querySelector('.BottomDrawer') as HTMLElement;
-    expect(drawer.style.minHeight).toBe('900px');
+    expect(drawer.style.height).toBe('900px');
   });
 
   it('fullscreen toggle restores previous height', () => {
@@ -178,13 +178,13 @@ describe('BottomDrawerContainer', () => {
     act(() => {
       fireEvent.click(getByTestId('btn-fullscreen'));
     });
-    expect(drawer.style.minHeight).toBe('900px');
+    expect(drawer.style.height).toBe('900px');
 
     // Un-fullscreen should restore to previous height (400px default)
     act(() => {
       fireEvent.click(getByTestId('btn-fullscreen'));
     });
-    expect(drawer.style.minHeight).toBe('400px');
+    expect(drawer.style.height).toBe('400px');
   });
 
   it('passes correct isMinimized and isFullscreen props to tabs', () => {
@@ -218,19 +218,19 @@ describe('BottomDrawerContainer', () => {
     expect(dragHandle).toBeTruthy();
 
     // Drawer starts at 400px from tab expansion
-    expect(drawer.style.minHeight).toBe('400px');
+    expect(drawer.style.height).toBe('400px');
 
     // Double-click to minimize
     act(() => {
       fireEvent.click(dragHandle, { detail: 2 });
     });
-    expect(drawer.style.minHeight).toBe('32px');
+    expect(drawer.style.height).toBe('32px');
 
     // Double-click again to restore default
     act(() => {
       fireEvent.click(dragHandle, { detail: 2 });
     });
-    expect(drawer.style.minHeight).toBe('400px');
+    expect(drawer.style.height).toBe('400px');
   });
 
   it('event bus onResize sets height', () => {
@@ -249,7 +249,7 @@ describe('BottomDrawerContainer', () => {
     });
 
     const drawer = container.querySelector('.BottomDrawer') as HTMLElement;
-    expect(drawer.style.minHeight).toBe('600px');
+    expect(drawer.style.height).toBe('600px');
   });
 
   it('event bus onFullscreen sets height to window.innerHeight', () => {
@@ -267,7 +267,7 @@ describe('BottomDrawerContainer', () => {
     });
 
     const drawer = container.querySelector('.BottomDrawer') as HTMLElement;
-    expect(drawer.style.minHeight).toBe('900px');
+    expect(drawer.style.height).toBe('900px');
   });
 
   it('event bus onMinimize sets height to minHeight', () => {
@@ -285,7 +285,7 @@ describe('BottomDrawerContainer', () => {
     });
 
     const drawer = container.querySelector('.BottomDrawer') as HTMLElement;
-    expect(drawer.style.minHeight).toBe('32px');
+    expect(drawer.style.height).toBe('32px');
   });
 
   it('renders terminal container for terminal tab variant', () => {

--- a/ui/layouts/core/main/BottomDrawer/index.tsx
+++ b/ui/layouts/core/main/BottomDrawer/index.tsx
@@ -240,7 +240,7 @@ const BottomDrawerContainer: React.FC = () => {
       document.removeEventListener('mousemove', handleMouseMove);
       document.removeEventListener('mouseup', handleMouseUp);
     };
-  }, [isDragging, handleMouseMove]);
+  }, [isDragging, handleMouseMove, handleMouseUp]);
 
   return (
     <>

--- a/ui/layouts/core/main/BottomDrawer/index.tsx
+++ b/ui/layouts/core/main/BottomDrawer/index.tsx
@@ -76,13 +76,13 @@ const BottomDrawerContainer: React.FC = () => {
     }
     expandDrawerToHeight(minHeight)
     bottomDrawerChannel.emit('onResizeReset')
-  }, [height]);
+  }, [height, expandDrawerToHeight]);
 
   // expand to last known expanded height (or default)
   const expand = React.useCallback(() => {
     expandDrawerToHeight(lastExpandedHeightRef.current)
     bottomDrawerChannel.emit('onResizeReset')
-  }, [])
+  }, [expandDrawerToHeight])
 
   // fullscreen toggle
   const fullscreen = React.useCallback(() => {
@@ -97,7 +97,7 @@ const BottomDrawerContainer: React.FC = () => {
       expandDrawerToHeight(window.innerHeight)
     }
     bottomDrawerChannel.emit('onResizeReset')
-  }, [height])
+  }, [height, expandDrawerToHeight])
 
 
   // ========================== EVENT BUS HANDLING ========================== //
@@ -138,7 +138,7 @@ const BottomDrawerContainer: React.FC = () => {
       closerFullScreen();
       closerMinimize();
     };
-  }, []);
+  }, [expandDrawerToHeight]);
 
   React.useEffect(() => {
     if (!drawerRef.current) {
@@ -153,7 +153,7 @@ const BottomDrawerContainer: React.FC = () => {
     } else if (tabs.length === 0) {
       expandDrawerToHeight(minHeight);
     }
-  }, [tabs]);
+  }, [tabs, expandDrawerToHeight]);
 
   const handleClick = React.useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     if (!drawerRef.current) {

--- a/ui/layouts/core/main/BottomDrawer/index.tsx
+++ b/ui/layouts/core/main/BottomDrawer/index.tsx
@@ -63,6 +63,7 @@ const BottomDrawerContainer: React.FC = () => {
     }
 
     drawerRef.current.style.height = `${height}px`;
+    drawerRef.current.style.minHeight = `${minHeight}px`;
     drawerRef.current.style.maxHeight = `${height}px`;
     setDrawerHeight(height);
   }, []);
@@ -163,6 +164,7 @@ const BottomDrawerContainer: React.FC = () => {
     if (e.detail === 2) {
       if (drawerRef.current.style.height === `${minHeight}px`) {
         drawerRef.current.style.height = `${defaultHeight}px`;
+        drawerRef.current.style.minHeight = `${minHeight}px`;
         drawerRef.current.style.maxHeight = `${defaultHeight}px`;
         setDrawerHeight(defaultHeight);
         bottomDrawerChannel.emit('onResizeReset')
@@ -170,6 +172,7 @@ const BottomDrawerContainer: React.FC = () => {
       }
 
       drawerRef.current.style.height = `${minHeight}px`;
+      drawerRef.current.style.minHeight = `${minHeight}px`;
       drawerRef.current.style.maxHeight = `${minHeight}px`;
 
       setDrawerHeight(minHeight);
@@ -193,6 +196,7 @@ const BottomDrawerContainer: React.FC = () => {
 
     // Directly update the drawer's height bypassing React's state
     drawerRef.current.style.height = `${newHeight}px`;
+    drawerRef.current.style.minHeight = `${minHeight}px`;
     drawerRef.current.style.maxHeight = `${newHeight}px`;
     bottomDrawerChannel.emit('onResizeHandler', newHeight);
   }, [isDragging, minHeight]);
@@ -210,6 +214,7 @@ const BottomDrawerContainer: React.FC = () => {
         setDrawerHeight(minHeight);
         bottomDrawerChannel.emit('onResizeReset')
         drawerRef.current.style.height = `${minHeight}px`;
+        drawerRef.current.style.minHeight = `${minHeight}px`;
         drawerRef.current.style.maxHeight = `${minHeight}px`;
         return;
       }

--- a/ui/layouts/core/main/BottomDrawer/index.tsx
+++ b/ui/layouts/core/main/BottomDrawer/index.tsx
@@ -62,7 +62,7 @@ const BottomDrawerContainer: React.FC = () => {
       lastExpandedHeightRef.current = height;
     }
 
-    drawerRef.current.style.minHeight = `${height}px`;
+    drawerRef.current.style.height = `${height}px`;
     drawerRef.current.style.maxHeight = `${height}px`;
     setDrawerHeight(height);
   }, []);
@@ -122,7 +122,7 @@ const BottomDrawerContainer: React.FC = () => {
 
     const unsubscribeOnTabCreated = bottomDrawerChannel.on('onTabCreated', () => {
       if (!drawerRef.current) return;
-      const cur = parseInt(drawerRef.current.style.minHeight, 10);
+      const cur = parseInt(drawerRef.current.style.height, 10);
       if (isNaN(cur) || cur < defaultHeight) {
         expandDrawerToHeight(defaultHeight);
       }
@@ -144,7 +144,7 @@ const BottomDrawerContainer: React.FC = () => {
       return;
     }
 
-    const currentHeight = parseInt(drawerRef.current.style.minHeight, 10);
+    const currentHeight = parseInt(drawerRef.current.style.height, 10);
 
     // if the tabs change, expand the window, or if there is a new tab
     if (tabs.length > 0 && (isNaN(currentHeight) || currentHeight < defaultHeight)) {
@@ -161,15 +161,15 @@ const BottomDrawerContainer: React.FC = () => {
 
     // if double click, reset height
     if (e.detail === 2) {
-      if (drawerRef.current.style.minHeight === `${minHeight}px`) {
-        drawerRef.current.style.minHeight = `${defaultHeight}px`;
+      if (drawerRef.current.style.height === `${minHeight}px`) {
+        drawerRef.current.style.height = `${defaultHeight}px`;
         drawerRef.current.style.maxHeight = `${defaultHeight}px`;
         setDrawerHeight(defaultHeight);
         bottomDrawerChannel.emit('onResizeReset')
         return;
       }
 
-      drawerRef.current.style.minHeight = `${minHeight}px`;
+      drawerRef.current.style.height = `${minHeight}px`;
       drawerRef.current.style.maxHeight = `${minHeight}px`;
 
       setDrawerHeight(minHeight);
@@ -192,7 +192,7 @@ const BottomDrawerContainer: React.FC = () => {
     const newHeight = Math.max(remainingHeightPx, minHeight);
 
     // Directly update the drawer's height bypassing React's state
-    drawerRef.current.style.minHeight = `${newHeight}px`;
+    drawerRef.current.style.height = `${newHeight}px`;
     drawerRef.current.style.maxHeight = `${newHeight}px`;
     bottomDrawerChannel.emit('onResizeHandler', newHeight);
   }, [isDragging, minHeight]);
@@ -201,7 +201,7 @@ const BottomDrawerContainer: React.FC = () => {
     setIsDragging(false);
     // Optionally sync your React state here if needed for other purposes
     if (drawerRef.current) {
-      const currentHeight = drawerRef.current.style.minHeight;
+      const currentHeight = drawerRef.current.style.height;
       const newHeight = Math.max(parseInt(currentHeight, 10), minHeight);
 
       // if we're pretty close to the bottom where it doesn't make sense
@@ -209,7 +209,7 @@ const BottomDrawerContainer: React.FC = () => {
       if (newHeight < 100) {
         setDrawerHeight(minHeight);
         bottomDrawerChannel.emit('onResizeReset')
-        drawerRef.current.style.minHeight = `${minHeight}px`;
+        drawerRef.current.style.height = `${minHeight}px`;
         drawerRef.current.style.maxHeight = `${minHeight}px`;
         return;
       }
@@ -252,7 +252,7 @@ const BottomDrawerContainer: React.FC = () => {
         sx={{
           zIndex: 1290,
           flexGrow: 0,
-          flexShrink: 0,
+          flexShrink: 1,
           display: 'flex',
           flexDirection: 'column',
           minHeight: minHeight,


### PR DESCRIPTION
## Summary
- Use `style.height` instead of `style.minHeight` for drawer sizing so the flex algorithm can shrink the drawer when the viewport is smaller than the desired height
- Change `flexShrink: 0` to `flexShrink: 1` so the drawer constrains to available space rather than overflowing past the viewport bottom
- The scroll area and scrollbar now remain fully visible instead of being clipped below the screen

## Test plan
- [x] Existing BottomDrawer tests updated to match new `style.height` property
- [x] LogViewer tests passing (15/15)
- [x] Manual: expand drawer, verify logs scroll to bottom and scrollbar is fully visible
- [x] Manual: drag resize, minimize, expand, fullscreen all still work correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * BottomDrawer sizing now consistently uses visible height across expand, collapse, drag, double-click reset and window-resize flows; respects min/max floors and locks when minimized or fullscreen.

* **Tests**
  * Added/updated tests validating height-based behavior, floor/ceiling enforcement, locking semantics, and transitions between minimized, expanded, and fullscreen states.

* **Refactor**
  * Internal sizing and event flows switched to height-driven logic for more consistent behavior.

* **Style**
  * Adjusted collapsed layout behavior to improve visual shrinking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->