### PR TITLE
fix: update runtime hooks to use ClientCreateInput/ClientUpdateInput

### DIFF
--- a/packages/omniviewdev-runtime/src/hooks/resource/useResource.ts
+++ b/packages/omniviewdev-runtime/src/hooks/resource/useResource.ts
@@ -62,7 +62,7 @@ export const useResource = ({
   // === Mutations === //
 
   const { mutateAsync: update } = useMutation({
-    mutationFn: async (opts: { input?: any }) => Update(pluginID, connectionID, resourceKey, resource.UpdateInput.createFrom({
+    mutationFn: async (opts: { input?: any }) => Update(pluginID, connectionID, resourceKey, resource.ClientUpdateInput.createFrom({
       input: opts.input,
       id: resourceID,
       namespace,

--- a/packages/omniviewdev-runtime/src/hooks/resource/useResourceMutations.ts
+++ b/packages/omniviewdev-runtime/src/hooks/resource/useResourceMutations.ts
@@ -65,7 +65,7 @@ export const useResourceMutations = ({ pluginID: explicitPluginID }: UseResource
         pluginID,
         opts.connectionID,
         opts.resourceKey,
-        resource.CreateInput.createFrom({
+        resource.ClientCreateInput.createFrom({
           input: input.input,
           namespace: input.namespace ?? opts.namespace ?? '',
         })
@@ -84,7 +84,7 @@ export const useResourceMutations = ({ pluginID: explicitPluginID }: UseResource
         pluginID,
         opts.connectionID,
         opts.resourceKey,
-        resource.UpdateInput.createFrom({
+        resource.ClientUpdateInput.createFrom({
           input: input.input,
           id: opts.resourceID,
           namespace: opts.namespace ?? '',

--- a/packages/omniviewdev-runtime/src/hooks/resource/useResources.ts
+++ b/packages/omniviewdev-runtime/src/hooks/resource/useResources.ts
@@ -82,7 +82,7 @@ export const useResources = ({
   // === Mutations === //
 
   const { mutateAsync: create } = useMutation({
-    mutationFn: async (opts: { input?: any; namespace?: string }) => Create(pluginID, connectionID, resourceKey, resourceModels.CreateInput.createFrom({
+    mutationFn: async (opts: { input?: any; namespace?: string }) => Create(pluginID, connectionID, resourceKey, resourceModels.ClientCreateInput.createFrom({
       input: opts.input,
       namespace: opts.namespace ?? (stableNamespaces.length === 1 ? stableNamespaces[0] : ''),
     })),

--- a/packages/omniviewdev-runtime/src/wailsjs/go/models.ts
+++ b/packages/omniviewdev-runtime/src/wailsjs/go/models.ts
@@ -2676,6 +2676,12 @@ export namespace time {
 
 export namespace trivy {
 	
+	export enum Scanner {
+	    VULN = "vuln",
+	    MISCONFIG = "misconfig",
+	    SECRET = "secret",
+	    LICENSE = "license",
+	}
 	export enum Command {
 	    CONFIG = "config",
 	    FILESYSTEM = "fs",
@@ -2684,12 +2690,6 @@ export namespace trivy {
 	    REPOSITORY = "repository",
 	    ROOTFS = "rootfs",
 	    SBOM = "sbom",
-	}
-	export enum Scanner {
-	    VULN = "vuln",
-	    MISCONFIG = "misconfig",
-	    SECRET = "secret",
-	    LICENSE = "license",
 	}
 	export class ScanOptions {
 	    filePatterns: string[];


### PR DESCRIPTION
Update mutation hooks to reference the renamed Wails-generated input types and bump all package versions to 0.2.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal resource mutation input handling to utilize revised input type structures.
  * Consolidated duplicate enum definition to improve code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->