### PR TITLE
feat: plugin hardening layer

### DIFF
--- a/ui/features/plugins/adapters/createProductionDeps.ts
+++ b/ui/features/plugins/adapters/createProductionDeps.ts
@@ -3,7 +3,9 @@ import { ensureBuiltinExtensionPointsRegistered } from '@/features/extensions/re
 import { EventsOn } from '@omniviewdev/runtime/runtime';
 import { validatePluginExports } from '../core/validation';
 import { MissingExtensionPointError } from '../core/errors';
-import type { PluginServiceDeps } from '../core/types';
+import { InMemoryCrashDataStrategy } from '../core/CrashDataService';
+import type { PluginServiceDeps, PluginServiceConfig } from '../core/types';
+import { DEFAULT_CONFIG } from '../core/types';
 import { importPlugin } from './importPlugin';
 import { clearPlugin } from './clearPlugin';
 import { ensureDevSharedDeps } from './devSharedDeps';
@@ -26,8 +28,12 @@ const pluginServiceLogger = {
  * Wires the real extension registry, SystemJS/ESM import adapters,
  * Wails event system, and real validation pipeline.
  */
-export function createProductionDeps(): PluginServiceDeps {
+export function createProductionDeps(config?: Partial<PluginServiceConfig>): PluginServiceDeps {
+  const resolved = { ...DEFAULT_CONFIG, ...config };
+  const crashData = new InMemoryCrashDataStrategy({ maxRecordsPerContribution: resolved.maxCrashRecordsPerContribution });
+
   return {
+    crashData,
     importPlugin,
     clearPlugin,
 

--- a/ui/features/plugins/adapters/createProductionDeps.ts
+++ b/ui/features/plugins/adapters/createProductionDeps.ts
@@ -2,7 +2,7 @@ import { EXTENSION_REGISTRY } from '@/features/extensions/store';
 import { ensureBuiltinExtensionPointsRegistered } from '@/features/extensions/registerBuiltinExtensionPoints';
 import { EventsOn } from '@omniviewdev/runtime/runtime';
 import { validatePluginExports } from '../core/validation';
-import { MissingExtensionPointError } from '../core/errors';
+import { MissingExtensionPointError, DuplicateContributionError } from '../core/errors';
 import { InMemoryCrashDataStrategy } from '../core/CrashDataService';
 import type { PluginServiceDeps, PluginServiceConfig } from '../core/types';
 import { DEFAULT_CONFIG } from '../core/types';
@@ -65,7 +65,20 @@ export function createProductionDeps(config?: Partial<PluginServiceConfig>): Plu
           },
         );
       }
-      store.register(contribution);
+      try {
+        store.register(contribution);
+      } catch (err) {
+        // Wrap the registry's plain Error into a typed error for structured handling
+        if (err instanceof Error && err.message.includes('already exists')) {
+          throw new DuplicateContributionError(err.message, {
+            pluginId: contribution.plugin,
+            extensionPointId,
+            contributionId: contribution.id,
+            cause: err,
+          });
+        }
+        throw err;
+      }
     },
 
     removeContributions: (pluginId) => {

--- a/ui/features/plugins/components/ExtensionPointRenderer.tsx
+++ b/ui/features/plugins/components/ExtensionPointRenderer.tsx
@@ -1,5 +1,5 @@
 'use no memo';
-import React from 'react';
+import React, { useContext, useSyncExternalStore } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import type { FallbackProps } from 'react-error-boundary';
 
@@ -11,6 +11,8 @@ import {
   logPluginBoundaryError,
 } from './PluginSurfaceBoundary';
 import type { DefaultExtensionFallbackProps } from './PluginSurfaceBoundary';
+import { QuarantinedContributionFallback } from './QuarantinedContributionFallback';
+import { PluginServiceContext } from '../react/context';
 
 // ─── Props ──────────────────────────────────────────────────────────
 
@@ -45,6 +47,8 @@ function ContributionWrapper({
   const pluginId = registration.plugin;
   const contributionId = registration.id;
 
+  const service = useContext(PluginServiceContext);
+
   const handleError = React.useCallback(
     (error: Error, info: React.ErrorInfo) => {
       logPluginBoundaryError({
@@ -56,8 +60,19 @@ function ContributionWrapper({
         stack: error.stack ?? '',
         componentStack: info.componentStack ?? '',
       });
+      // F3: Record crash and check quarantine threshold
+      service?.recordContributionCrash({
+        contributionId,
+        pluginId,
+        extensionPointId,
+        boundary: 'ExtensionPointRenderer',
+        errorMessage: error.message,
+        stack: error.stack,
+        componentStack: info.componentStack ?? undefined,
+        timestamp: Date.now(),
+      });
     },
-    [pluginId, extensionPointId, contributionId],
+    [pluginId, extensionPointId, contributionId, service],
   );
 
   const renderFallback = React.useCallback(
@@ -104,22 +119,51 @@ export function ExtensionPointRenderer<TContext extends ExtensionRenderContext =
   const extensionPoint = useExtensionPoint<React.ComponentType<any>, TContext>(extensionPointId);
   const registrations = extensionPoint?.list(context) ?? [];
 
+  const service = useContext(PluginServiceContext);
+
+  // Subscribe to service snapshot so quarantine state changes trigger re-render
+  useSyncExternalStore(
+    service?.subscribe.bind(service) ?? (() => () => {}),
+    service?.getSnapshot.bind(service) ?? (() => null),
+  );
+
+  const isQuarantined = (contributionId: string) => service?.isQuarantined(contributionId) ?? false;
+  const unquarantine = (contributionId: string) => service?.unquarantine(contributionId);
+
   if (registrations.length === 0) {
     return null;
   }
 
   return (
     <>
-      {registrations.map((registration) => (
-        <ContributionWrapper
-          key={registration.id}
-          registration={registration}
-          extensionPointId={extensionPointId}
-          fallback={fallback}
-          context={context}
-          componentProps={componentProps}
-        />
-      ))}
+      {registrations.map((registration) => {
+        if (isQuarantined(registration.id)) {
+          if (import.meta.env.DEV) {
+            return (
+              <QuarantinedContributionFallback
+                key={registration.id}
+                pluginId={registration.plugin}
+                extensionPointId={extensionPointId}
+                contributionId={registration.id}
+                crashCount={service?.getCrashCount(registration.id) ?? 0}
+                onReEnable={() => unquarantine(registration.id)}
+              />
+            );
+          }
+          return null;
+        }
+
+        return (
+          <ContributionWrapper
+            key={registration.id}
+            registration={registration}
+            extensionPointId={extensionPointId}
+            fallback={fallback}
+            context={context}
+            componentProps={componentProps}
+          />
+        );
+      })}
     </>
   );
 }

--- a/ui/features/plugins/components/PluginSurfaceBoundary.tsx
+++ b/ui/features/plugins/components/PluginSurfaceBoundary.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import type { FallbackProps } from 'react-error-boundary';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
+import { PluginServiceContext } from '../react/context';
 
 // ─── Boundary Log Event ─────────────────────────────────────────────
 
@@ -167,6 +168,8 @@ export function PluginSurfaceBoundary({
   fallback: FallbackComponent = DefaultPluginFallback,
   resetKeys,
 }: PluginSurfaceBoundaryProps): React.ReactElement {
+  const service = useContext(PluginServiceContext);
+
   const handleError = React.useCallback(
     (error: Error, info: React.ErrorInfo) => {
       logPluginBoundaryError({
@@ -177,8 +180,21 @@ export function PluginSurfaceBoundary({
         stack: error.stack ?? '',
         componentStack: info.componentStack ?? '',
       });
+      // F3: Record crash (no quarantine check — quarantine only applies to
+      // extension contributions rendered via ExtensionPointRenderer)
+      service?.recordBoundaryCrash({
+        contributionId: `${pluginId}/${boundary}${resourceKey ? `/${resourceKey}` : ''}`,
+        pluginId,
+        extensionPointId: '',
+        boundary,
+        resourceKey,
+        errorMessage: error.message,
+        stack: error.stack,
+        componentStack: info.componentStack ?? undefined,
+        timestamp: Date.now(),
+      });
     },
-    [pluginId, boundary, resourceKey],
+    [pluginId, boundary, resourceKey, service],
   );
 
   const renderFallback = React.useCallback(

--- a/ui/features/plugins/components/QuarantinedContributionFallback.tsx
+++ b/ui/features/plugins/components/QuarantinedContributionFallback.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+
+export interface QuarantinedContributionFallbackProps {
+  readonly pluginId: string;
+  readonly extensionPointId: string;
+  readonly contributionId: string;
+  readonly crashCount: number;
+  readonly onReEnable: () => void;
+}
+
+/**
+ * Dev-mode inline fallback for quarantined contributions.
+ * Shows which contribution was suppressed and offers a re-enable button.
+ * Only rendered in dev mode — production uses empty slots + notifications.
+ */
+export function QuarantinedContributionFallback({
+  pluginId,
+  extensionPointId,
+  contributionId,
+  crashCount,
+  onReEnable,
+}: QuarantinedContributionFallbackProps): React.ReactElement {
+  return (
+    <Box
+      role="alert"
+      sx={{
+        p: 1.5,
+        border: '1px dashed',
+        borderColor: 'warning.main',
+        borderRadius: 1,
+        bgcolor: 'warning.light',
+      }}
+    >
+      <Typography variant="caption" color="warning.main" fontWeight="bold">
+        Quarantined Extension
+      </Typography>
+      <Typography variant="caption" display="block" color="text.secondary">
+        Plugin: {pluginId}
+      </Typography>
+      <Typography variant="caption" display="block" color="text.secondary">
+        Extension Point: {extensionPointId}
+      </Typography>
+      <Typography variant="caption" display="block" color="text.secondary">
+        Contribution: {contributionId}
+      </Typography>
+      <Typography variant="caption" display="block" color="text.secondary">
+        Crashes: {crashCount}
+      </Typography>
+      <Button
+        size="small"
+        variant="outlined"
+        color="warning"
+        onClick={onReEnable}
+        sx={{ mt: 1 }}
+      >
+        Re-enable
+      </Button>
+    </Box>
+  );
+}

--- a/ui/features/plugins/core/CrashDataService.test.ts
+++ b/ui/features/plugins/core/CrashDataService.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi } from 'vitest';
+import { InMemoryCrashDataStrategy } from './CrashDataService';
+import type { CrashRecord } from './types';
+
+function makeCrashRecord(overrides?: Partial<CrashRecord>): CrashRecord {
+  return {
+    contributionId: 'plugin-a/sidebar/apps::v1::Deployment',
+    pluginId: 'plugin-a',
+    extensionPointId: 'omniview/resource/sidebar/infopanel',
+    boundary: 'ExtensionPointRenderer',
+    errorMessage: 'Component crashed',
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('InMemoryCrashDataStrategy', () => {
+  describe('recordCrash', () => {
+    it('stores a crash record', () => {
+      const strategy = new InMemoryCrashDataStrategy({ maxRecordsPerContribution: 10 });
+      const record = makeCrashRecord();
+      strategy.recordCrash(record);
+      expect(strategy.getCrashCount(record.contributionId)).toBe(1);
+      expect(strategy.getCrashHistory(record.contributionId)).toEqual([record]);
+    });
+
+    it('stores multiple crashes for the same contribution', () => {
+      const strategy = new InMemoryCrashDataStrategy({ maxRecordsPerContribution: 10 });
+      const r1 = makeCrashRecord({ timestamp: 1 });
+      const r2 = makeCrashRecord({ timestamp: 2 });
+      strategy.recordCrash(r1);
+      strategy.recordCrash(r2);
+      expect(strategy.getCrashCount(r1.contributionId)).toBe(2);
+      expect(strategy.getCrashHistory(r1.contributionId)).toEqual([r1, r2]);
+    });
+
+    it('evicts oldest records when cap is reached', () => {
+      const strategy = new InMemoryCrashDataStrategy({ maxRecordsPerContribution: 3 });
+      const records = [1, 2, 3, 4].map((t) => makeCrashRecord({ timestamp: t }));
+      for (const r of records) strategy.recordCrash(r);
+      expect(strategy.getCrashCount(records[0].contributionId)).toBe(4);
+      const history = strategy.getCrashHistory(records[0].contributionId);
+      expect(history).toHaveLength(3);
+      expect(history[0].timestamp).toBe(2);
+      expect(history[2].timestamp).toBe(4);
+    });
+
+    it('notifies subscribers on recordCrash', () => {
+      const strategy = new InMemoryCrashDataStrategy({ maxRecordsPerContribution: 10 });
+      const listener = vi.fn();
+      strategy.subscribe(listener);
+      strategy.recordCrash(makeCrashRecord());
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('clearForContribution', () => {
+    it('removes all records for a contribution', () => {
+      const strategy = new InMemoryCrashDataStrategy({ maxRecordsPerContribution: 10 });
+      strategy.recordCrash(makeCrashRecord());
+      strategy.recordCrash(makeCrashRecord());
+      strategy.clearForContribution('plugin-a/sidebar/apps::v1::Deployment');
+      expect(strategy.getCrashCount('plugin-a/sidebar/apps::v1::Deployment')).toBe(0);
+      expect(strategy.getCrashHistory('plugin-a/sidebar/apps::v1::Deployment')).toEqual([]);
+    });
+
+    it('does not affect other contributions', () => {
+      const strategy = new InMemoryCrashDataStrategy({ maxRecordsPerContribution: 10 });
+      strategy.recordCrash(makeCrashRecord({ contributionId: 'a' }));
+      strategy.recordCrash(makeCrashRecord({ contributionId: 'b' }));
+      strategy.clearForContribution('a');
+      expect(strategy.getCrashCount('a')).toBe(0);
+      expect(strategy.getCrashCount('b')).toBe(1);
+    });
+
+    it('notifies subscribers', () => {
+      const strategy = new InMemoryCrashDataStrategy({ maxRecordsPerContribution: 10 });
+      strategy.recordCrash(makeCrashRecord());
+      const listener = vi.fn();
+      strategy.subscribe(listener);
+      strategy.clearForContribution('plugin-a/sidebar/apps::v1::Deployment');
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('clearForPlugin', () => {
+    it('removes all records for contributions belonging to a plugin', () => {
+      const strategy = new InMemoryCrashDataStrategy({ maxRecordsPerContribution: 10 });
+      strategy.recordCrash(makeCrashRecord({ contributionId: 'c1', pluginId: 'plugin-a' }));
+      strategy.recordCrash(makeCrashRecord({ contributionId: 'c2', pluginId: 'plugin-a' }));
+      strategy.recordCrash(makeCrashRecord({ contributionId: 'c3', pluginId: 'plugin-b' }));
+      strategy.clearForPlugin('plugin-a');
+      expect(strategy.getCrashCount('c1')).toBe(0);
+      expect(strategy.getCrashCount('c2')).toBe(0);
+      expect(strategy.getCrashCount('c3')).toBe(1);
+    });
+
+    it('notifies subscribers', () => {
+      const strategy = new InMemoryCrashDataStrategy({ maxRecordsPerContribution: 10 });
+      strategy.recordCrash(makeCrashRecord({ contributionId: 'c1', pluginId: 'plugin-a' }));
+      const listener = vi.fn();
+      strategy.subscribe(listener);
+      strategy.clearForPlugin('plugin-a');
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('clearAll', () => {
+    it('removes all records', () => {
+      const strategy = new InMemoryCrashDataStrategy({ maxRecordsPerContribution: 10 });
+      strategy.recordCrash(makeCrashRecord({ contributionId: 'c1' }));
+      strategy.recordCrash(makeCrashRecord({ contributionId: 'c2' }));
+      strategy.clearAll();
+      expect(strategy.getCrashCount('c1')).toBe(0);
+      expect(strategy.getCrashCount('c2')).toBe(0);
+      expect(strategy.getAllCrashHistory().size).toBe(0);
+    });
+
+    it('notifies subscribers', () => {
+      const strategy = new InMemoryCrashDataStrategy({ maxRecordsPerContribution: 10 });
+      strategy.recordCrash(makeCrashRecord({ contributionId: 'c1' }));
+      const listener = vi.fn();
+      strategy.subscribe(listener);
+      strategy.clearAll();
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getCrashCount', () => {
+    it('returns 0 for unknown contribution', () => {
+      const strategy = new InMemoryCrashDataStrategy({ maxRecordsPerContribution: 10 });
+      expect(strategy.getCrashCount('unknown')).toBe(0);
+    });
+
+    it('tracks count independently of record cap', () => {
+      const strategy = new InMemoryCrashDataStrategy({ maxRecordsPerContribution: 2 });
+      for (let i = 0; i < 5; i++) {
+        strategy.recordCrash(makeCrashRecord({ timestamp: i }));
+      }
+      expect(strategy.getCrashCount(makeCrashRecord().contributionId)).toBe(5);
+      expect(strategy.getCrashHistory(makeCrashRecord().contributionId)).toHaveLength(2);
+    });
+  });
+
+  describe('getAllCrashHistory', () => {
+    it('returns all contributions with history', () => {
+      const strategy = new InMemoryCrashDataStrategy({ maxRecordsPerContribution: 10 });
+      strategy.recordCrash(makeCrashRecord({ contributionId: 'c1' }));
+      strategy.recordCrash(makeCrashRecord({ contributionId: 'c2' }));
+      const all = strategy.getAllCrashHistory();
+      expect(all.size).toBe(2);
+      expect(all.has('c1')).toBe(true);
+      expect(all.has('c2')).toBe(true);
+    });
+  });
+
+  describe('subscribe', () => {
+    it('returns an unsubscribe function', () => {
+      const strategy = new InMemoryCrashDataStrategy({ maxRecordsPerContribution: 10 });
+      const listener = vi.fn();
+      const unsub = strategy.subscribe(listener);
+      strategy.recordCrash(makeCrashRecord());
+      expect(listener).toHaveBeenCalledTimes(1);
+      unsub();
+      strategy.recordCrash(makeCrashRecord());
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/ui/features/plugins/core/CrashDataService.ts
+++ b/ui/features/plugins/core/CrashDataService.ts
@@ -1,0 +1,96 @@
+import type { CrashRecord, CrashDataStrategy } from './types';
+
+interface CrashEntry {
+  records: CrashRecord[];
+  count: number;
+  pluginId: string;
+}
+
+export interface InMemoryCrashDataStrategyConfig {
+  readonly maxRecordsPerContribution: number;
+}
+
+export class InMemoryCrashDataStrategy implements CrashDataStrategy {
+  private readonly maxRecords: number;
+  private readonly entries = new Map<string, CrashEntry>();
+  private readonly listeners = new Set<() => void>();
+
+  constructor(config: InMemoryCrashDataStrategyConfig) {
+    if (!Number.isInteger(config.maxRecordsPerContribution) || config.maxRecordsPerContribution < 1) {
+      throw new Error(`maxRecordsPerContribution must be a positive integer, got ${config.maxRecordsPerContribution}`);
+    }
+    this.maxRecords = config.maxRecordsPerContribution;
+  }
+
+  recordCrash(record: CrashRecord): void {
+    const entry = this.entries.get(record.contributionId);
+    if (entry) {
+      entry.records.push(record);
+      entry.count++;
+      while (entry.records.length > this.maxRecords) {
+        entry.records.shift();
+      }
+    } else {
+      this.entries.set(record.contributionId, {
+        records: [record],
+        count: 1,
+        pluginId: record.pluginId,
+      });
+    }
+    this.notify();
+  }
+
+  clearForContribution(contributionId: string): void {
+    if (this.entries.delete(contributionId)) {
+      this.notify();
+    }
+  }
+
+  clearForPlugin(pluginId: string): void {
+    let changed = false;
+    for (const [id, entry] of this.entries) {
+      if (entry.pluginId === pluginId) {
+        this.entries.delete(id);
+        changed = true;
+      }
+    }
+    if (changed) this.notify();
+  }
+
+  clearAll(): void {
+    if (this.entries.size > 0) {
+      this.entries.clear();
+      this.notify();
+    }
+  }
+
+  getCrashCount(contributionId: string): number {
+    return this.entries.get(contributionId)?.count ?? 0;
+  }
+
+  getCrashHistory(contributionId: string): readonly CrashRecord[] {
+    const entry = this.entries.get(contributionId);
+    return entry ? [...entry.records] : [];
+  }
+
+  getAllCrashHistory(): ReadonlyMap<string, readonly CrashRecord[]> {
+    const result = new Map<string, readonly CrashRecord[]>();
+    for (const [id, entry] of this.entries) {
+      result.set(id, [...entry.records]);
+    }
+    return result;
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private notify(): void {
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+}

--- a/ui/features/plugins/core/DependencyAnalyzer.test.ts
+++ b/ui/features/plugins/core/DependencyAnalyzer.test.ts
@@ -8,7 +8,9 @@ describe('DependencyAnalyzer', () => {
       analyzer.addPlugin('plugin-a', { plugins: ['plugin-b'], extensionPoints: ['ep/1'] });
       const graph = analyzer.getGraph();
       expect(graph.nodes).toContain('plugin-a');
+      expect(graph.nodes).toContain('ep/1');
       expect(graph.edges).toContainEqual(['plugin-a', 'plugin-b']);
+      expect(graph.edges).toContainEqual(['plugin-a', 'ep/1']);
     });
 
     it('removes a plugin and its edges', () => {
@@ -26,6 +28,17 @@ describe('DependencyAnalyzer', () => {
       const graph = analyzer.getGraph();
       expect(graph.nodes).toContain('plugin-a');
       expect(graph.edges).toHaveLength(0);
+    });
+
+    it('clear() resets all state', () => {
+      const analyzer = new DependencyAnalyzer();
+      analyzer.addPlugin('a', { plugins: ['b'], extensionPoints: ['ep/1'] });
+      analyzer.addPlugin('b', { plugins: ['a'], extensionPoints: [] });
+      analyzer.clear();
+      const graph = analyzer.getGraph();
+      expect(graph.nodes).toHaveLength(0);
+      expect(graph.edges).toHaveLength(0);
+      expect(analyzer.detectCycles()).toEqual([]);
     });
   });
 
@@ -135,6 +148,14 @@ describe('DependencyAnalyzer', () => {
       const graph = analyzer.getGraph();
       expect(graph.nodes).toEqual(expect.arrayContaining(['a', 'b', 'c']));
       expect(graph.edges).toEqual(expect.arrayContaining([['a', 'b'], ['a', 'c']]));
+    });
+
+    it('includes extension point dependencies as edges', () => {
+      const analyzer = new DependencyAnalyzer();
+      analyzer.addPlugin('a', { plugins: ['b'], extensionPoints: ['ep/1', 'ep/2'] });
+      const graph = analyzer.getGraph();
+      expect(graph.nodes).toEqual(expect.arrayContaining(['a', 'b', 'ep/1', 'ep/2']));
+      expect(graph.edges).toEqual(expect.arrayContaining([['a', 'b'], ['a', 'ep/1'], ['a', 'ep/2']]));
     });
   });
 });

--- a/ui/features/plugins/core/DependencyAnalyzer.test.ts
+++ b/ui/features/plugins/core/DependencyAnalyzer.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import { DependencyAnalyzer } from './DependencyAnalyzer';
+
+describe('DependencyAnalyzer', () => {
+  describe('addPlugin / removePlugin', () => {
+    it('adds a plugin with dependencies', () => {
+      const analyzer = new DependencyAnalyzer();
+      analyzer.addPlugin('plugin-a', { plugins: ['plugin-b'], extensionPoints: ['ep/1'] });
+      const graph = analyzer.getGraph();
+      expect(graph.nodes).toContain('plugin-a');
+      expect(graph.edges).toContainEqual(['plugin-a', 'plugin-b']);
+    });
+
+    it('removes a plugin and its edges', () => {
+      const analyzer = new DependencyAnalyzer();
+      analyzer.addPlugin('plugin-a', { plugins: ['plugin-b'], extensionPoints: [] });
+      analyzer.removePlugin('plugin-a');
+      const graph = analyzer.getGraph();
+      expect(graph.nodes).not.toContain('plugin-a');
+      expect(graph.edges).toHaveLength(0);
+    });
+
+    it('handles plugin with no dependencies', () => {
+      const analyzer = new DependencyAnalyzer();
+      analyzer.addPlugin('plugin-a', { plugins: [], extensionPoints: [] });
+      const graph = analyzer.getGraph();
+      expect(graph.nodes).toContain('plugin-a');
+      expect(graph.edges).toHaveLength(0);
+    });
+  });
+
+  describe('detectCycles', () => {
+    it('returns empty for acyclic graph', () => {
+      const analyzer = new DependencyAnalyzer();
+      analyzer.addPlugin('a', { plugins: ['b'], extensionPoints: [] });
+      analyzer.addPlugin('b', { plugins: ['c'], extensionPoints: [] });
+      analyzer.addPlugin('c', { plugins: [], extensionPoints: [] });
+      expect(analyzer.detectCycles()).toEqual([]);
+    });
+
+    it('detects a simple 2-node cycle as one group', () => {
+      const analyzer = new DependencyAnalyzer();
+      analyzer.addPlugin('a', { plugins: ['b'], extensionPoints: [] });
+      analyzer.addPlugin('b', { plugins: ['a'], extensionPoints: [] });
+      const cycles = analyzer.detectCycles();
+      expect(cycles).toHaveLength(1);
+      expect(cycles[0]).toEqual(expect.arrayContaining(['a', 'b']));
+      expect(cycles[0]).toHaveLength(2);
+    });
+
+    it('detects a 3-node cycle as one group', () => {
+      const analyzer = new DependencyAnalyzer();
+      analyzer.addPlugin('a', { plugins: ['b'], extensionPoints: [] });
+      analyzer.addPlugin('b', { plugins: ['c'], extensionPoints: [] });
+      analyzer.addPlugin('c', { plugins: ['a'], extensionPoints: [] });
+      const cycles = analyzer.detectCycles();
+      expect(cycles).toHaveLength(1);
+      expect(cycles[0]).toEqual(expect.arrayContaining(['a', 'b', 'c']));
+    });
+
+    it('detects two independent cycles as separate groups', () => {
+      const analyzer = new DependencyAnalyzer();
+      analyzer.addPlugin('a', { plugins: ['b'], extensionPoints: [] });
+      analyzer.addPlugin('b', { plugins: ['a'], extensionPoints: [] });
+      analyzer.addPlugin('x', { plugins: ['y'], extensionPoints: [] });
+      analyzer.addPlugin('y', { plugins: ['x'], extensionPoints: [] });
+      const cycles = analyzer.detectCycles();
+      expect(cycles).toHaveLength(2);
+      const allNodes = cycles.flat().sort();
+      expect(allNodes).toEqual(['a', 'b', 'x', 'y']);
+    });
+
+    it('handles self-dependency', () => {
+      const analyzer = new DependencyAnalyzer();
+      analyzer.addPlugin('a', { plugins: ['a'], extensionPoints: [] });
+      const cycles = analyzer.detectCycles();
+      expect(cycles).toHaveLength(1);
+      expect(cycles[0]).toEqual(['a']);
+    });
+
+    it('excludes acyclic nodes from cycle groups', () => {
+      const analyzer = new DependencyAnalyzer();
+      analyzer.addPlugin('a', { plugins: ['b'], extensionPoints: [] });
+      analyzer.addPlugin('b', { plugins: ['a'], extensionPoints: [] });
+      analyzer.addPlugin('c', { plugins: ['a'], extensionPoints: [] }); // c depends on a but not cyclic
+      const cycles = analyzer.detectCycles();
+      expect(cycles).toHaveLength(1);
+      expect(cycles[0]).toEqual(expect.arrayContaining(['a', 'b']));
+      expect(cycles[0]).not.toContain('c');
+    });
+  });
+
+  describe('checkMissingDependencies', () => {
+    it('returns missing plugins', () => {
+      const analyzer = new DependencyAnalyzer();
+      analyzer.addPlugin('a', { plugins: ['b', 'c'], extensionPoints: [] });
+      const loadedPlugins = new Set(['a']);
+      const registeredEPs = new Set<string>();
+      const warnings = analyzer.checkMissingDependencies('a', loadedPlugins, registeredEPs);
+      expect(warnings).toContain('Plugin "a" declares dependency on plugin "b" which is not loaded');
+      expect(warnings).toContain('Plugin "a" declares dependency on plugin "c" which is not loaded');
+    });
+
+    it('returns missing extension points', () => {
+      const analyzer = new DependencyAnalyzer();
+      analyzer.addPlugin('a', { plugins: [], extensionPoints: ['ep/1', 'ep/2'] });
+      const loadedPlugins = new Set(['a']);
+      const registeredEPs = new Set(['ep/1']);
+      const warnings = analyzer.checkMissingDependencies('a', loadedPlugins, registeredEPs);
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('ep/2');
+    });
+
+    it('returns empty when all dependencies are met', () => {
+      const analyzer = new DependencyAnalyzer();
+      analyzer.addPlugin('a', { plugins: ['b'], extensionPoints: ['ep/1'] });
+      const loadedPlugins = new Set(['a', 'b']);
+      const registeredEPs = new Set(['ep/1']);
+      const warnings = analyzer.checkMissingDependencies('a', loadedPlugins, registeredEPs);
+      expect(warnings).toHaveLength(0);
+    });
+
+    it('returns empty for plugin with no declared dependencies', () => {
+      const analyzer = new DependencyAnalyzer();
+      const warnings = analyzer.checkMissingDependencies('a', new Set(['a']), new Set());
+      expect(warnings).toHaveLength(0);
+    });
+  });
+
+  describe('getGraph', () => {
+    it('returns all nodes and edges', () => {
+      const analyzer = new DependencyAnalyzer();
+      analyzer.addPlugin('a', { plugins: ['b', 'c'], extensionPoints: [] });
+      analyzer.addPlugin('b', { plugins: [], extensionPoints: [] });
+      const graph = analyzer.getGraph();
+      expect(graph.nodes).toEqual(expect.arrayContaining(['a', 'b', 'c']));
+      expect(graph.edges).toEqual(expect.arrayContaining([['a', 'b'], ['a', 'c']]));
+    });
+  });
+});

--- a/ui/features/plugins/core/DependencyAnalyzer.ts
+++ b/ui/features/plugins/core/DependencyAnalyzer.ts
@@ -128,7 +128,7 @@ export class DependencyAnalyzer {
 
   /**
    * Returns a snapshot of the full dependency graph: all known nodes and directed edges.
-   * An edge [A, B] means plugin A declares a dependency on B.
+   * An edge [A, B] means plugin A declares a dependency on B (plugin or extension point).
    */
   getGraph(): DependencyGraph {
     const nodes = new Set<string>();
@@ -139,6 +139,10 @@ export class DependencyAnalyzer {
       for (const dep of entry.plugins) {
         nodes.add(dep);
         edges.push([pluginId, dep]);
+      }
+      for (const ep of entry.extensionPoints) {
+        nodes.add(ep);
+        edges.push([pluginId, ep]);
       }
     }
 

--- a/ui/features/plugins/core/DependencyAnalyzer.ts
+++ b/ui/features/plugins/core/DependencyAnalyzer.ts
@@ -1,0 +1,147 @@
+import type { DeclaredDependencies, DependencyGraph } from './types';
+
+interface PluginDependencyEntry {
+  readonly plugins: readonly string[];
+  readonly extensionPoints: readonly string[];
+}
+
+export class DependencyAnalyzer {
+  private readonly entries = new Map<string, PluginDependencyEntry>();
+
+  addPlugin(pluginId: string, deps: DeclaredDependencies): void {
+    this.entries.set(pluginId, {
+      plugins: [...deps.plugins],
+      extensionPoints: [...deps.extensionPoints],
+    });
+  }
+
+  removePlugin(pluginId: string): void {
+    this.entries.delete(pluginId);
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+
+  /**
+   * Detects cycles using Tarjan's SCC algorithm.
+   * Returns an array of cycle groups — each group is a strongly connected component
+   * with more than one node (or a self-loop). Acyclic nodes are excluded.
+   * All operations are advisory — they never block loading.
+   */
+  detectCycles(): string[][] {
+    // Build adjacency list (only plugin→plugin edges matter for cycles)
+    const adj = new Map<string, string[]>();
+    for (const [pluginId, entry] of this.entries) {
+      if (!adj.has(pluginId)) adj.set(pluginId, []);
+      for (const dep of entry.plugins) {
+        if (!adj.has(dep)) adj.set(dep, []);
+        adj.get(pluginId)!.push(dep);
+      }
+    }
+
+    // Tarjan's SCC
+    let index = 0;
+    const indices = new Map<string, number>();
+    const lowlinks = new Map<string, number>();
+    const onStack = new Set<string>();
+    const stack: string[] = [];
+    const sccs: string[][] = [];
+
+    const strongconnect = (v: string): void => {
+      indices.set(v, index);
+      lowlinks.set(v, index);
+      index++;
+      stack.push(v);
+      onStack.add(v);
+
+      for (const w of adj.get(v) ?? []) {
+        if (!indices.has(w)) {
+          strongconnect(w);
+          lowlinks.set(v, Math.min(lowlinks.get(v)!, lowlinks.get(w)!));
+        } else if (onStack.has(w)) {
+          lowlinks.set(v, Math.min(lowlinks.get(v)!, indices.get(w)!));
+        }
+      }
+
+      if (lowlinks.get(v) === indices.get(v)) {
+        const scc: string[] = [];
+        let w: string;
+        do {
+          w = stack.pop()!;
+          onStack.delete(w);
+          scc.push(w);
+        } while (w !== v);
+        sccs.push(scc);
+      }
+    };
+
+    for (const node of adj.keys()) {
+      if (!indices.has(node)) {
+        strongconnect(node);
+      }
+    }
+
+    // Filter to only SCCs that represent actual cycles:
+    // - SCCs with 2+ nodes are always cycles
+    // - SCCs with 1 node are cycles only if there's a self-edge
+    return sccs.filter((scc) => {
+      if (scc.length > 1) return true;
+      const node = scc[0];
+      return (adj.get(node) ?? []).includes(node);
+    });
+  }
+
+  /**
+   * Checks whether all declared dependencies for a plugin are currently available.
+   * Returns a list of human-readable warning strings for anything missing.
+   * Advisory only — does not prevent loading.
+   */
+  checkMissingDependencies(
+    pluginId: string,
+    loadedPlugins: ReadonlySet<string>,
+    registeredExtensionPoints: ReadonlySet<string>,
+  ): string[] {
+    const entry = this.entries.get(pluginId);
+    if (!entry) return [];
+
+    const warnings: string[] = [];
+
+    for (const dep of entry.plugins) {
+      if (!loadedPlugins.has(dep)) {
+        warnings.push(
+          `Plugin "${pluginId}" declares dependency on plugin "${dep}" which is not loaded`,
+        );
+      }
+    }
+
+    for (const ep of entry.extensionPoints) {
+      if (!registeredExtensionPoints.has(ep)) {
+        warnings.push(
+          `Plugin "${pluginId}" declares dependency on extension point "${ep}" which is not registered`,
+        );
+      }
+    }
+
+    return warnings;
+  }
+
+  /**
+   * Returns a snapshot of the full dependency graph: all known nodes and directed edges.
+   * An edge [A, B] means plugin A declares a dependency on B.
+   */
+  getGraph(): DependencyGraph {
+    const nodes = new Set<string>();
+    const edges: [string, string][] = [];
+
+    for (const [pluginId, entry] of this.entries) {
+      nodes.add(pluginId);
+      for (const dep of entry.plugins) {
+        nodes.add(dep);
+        edges.push([pluginId, dep]);
+      }
+    }
+
+    return { nodes: [...nodes], edges };
+  }
+}

--- a/ui/features/plugins/core/PluginService.test.ts
+++ b/ui/features/plugins/core/PluginService.test.ts
@@ -231,7 +231,7 @@ describe('Group 3: Load Operations', () => {
       expect(s.service.getPluginState('A')?.phase).toBe('error');
     });
 
-    it('#22 load fails fast on missing extension point', async () => {
+    it('#22 load soft-resolves missing extension point (contribution held pending)', async () => {
       s.importer.register('A', validModule({
         extensionRegistrations: [{
           extensionPointId: 'missing-ep',
@@ -239,7 +239,8 @@ describe('Group 3: Load Operations', () => {
         }],
       }));
       await s.service.load('A');
-      expect(s.service.getPluginState('A')?.phase).toBe('error');
+      expect(s.service.getPluginState('A')?.phase).toBe('ready');
+      expect(s.service.getPendingContributions().get('missing-ep')).toHaveLength(1);
     });
 
     it('#24 error state has null pluginWindow', async () => {
@@ -990,7 +991,7 @@ describe('Group 11: Batch Operations (loadAll)', () => {
     expect(store?.listAll()).toHaveLength(1);
   });
 
-  it('#13 genuine missing target EP still fails', async () => {
+  it('#13 missing target EP soft-resolves (contribution held pending)', async () => {
     const s = setup();
     s.importer.register('A', validModule({
       extensionRegistrations: [{
@@ -1007,9 +1008,10 @@ describe('Group 11: Batch Operations (loadAll)', () => {
       { id: 'C', dev: false },
     ]);
 
-    expect(s.service.getPluginState('A')?.phase).toBe('error');
+    expect(s.service.getPluginState('A')?.phase).toBe('ready');
     expect(s.service.getPluginState('B')?.phase).toBe('ready');
     expect(s.service.getPluginState('C')?.phase).toBe('ready');
+    expect(s.service.getPendingContributions().get('missing-ep')).toHaveLength(1);
   });
 });
 

--- a/ui/features/plugins/core/PluginService.ts
+++ b/ui/features/plugins/core/PluginService.ts
@@ -394,6 +394,8 @@ export class PluginService {
       if (!this.isCurrentGeneration(pluginId, generation)) return;
 
       const validated = this.deps.validateExports(rawModule);
+      const rawDeps = (rawModule as Record<string, unknown>)?.dependencies;
+      const declaredDependencies = extractDeclaredDependencies(rawDeps);
       const normalizedContributions = normalizeContributions(pluginId, validated);
       const extensionPoints = this.extractExtensionPoints(validated);
       const registrationsObj = this.buildRegistrations(validated);
@@ -417,6 +419,25 @@ export class PluginService {
         { excludePluginId: pluginId },
       );
 
+      // F1: Update dependency data
+      this.dependencyAnalyzer.removePlugin(pluginId);
+      if (declaredDependencies) {
+        this.dependencyAnalyzer.addPlugin(pluginId, declaredDependencies);
+
+        const cycles = this.dependencyAnalyzer.detectCycles();
+        if (cycles.length > 0) {
+          this.deps.log.warn(
+            `Dependency cycle detected after retrying "${pluginId}": ${cycles.map((c) => c.join(' → ')).join('; ')}`,
+            { pluginId, cycles },
+          );
+        }
+
+        const depWarnings = this.getDependencyWarnings(pluginId);
+        for (const w of depWarnings) {
+          this.deps.log.warn(w, { pluginId });
+        }
+      }
+
       this.transition(pluginId, 'ready', {
         pluginWindow: validated.plugin,
         loadedAt: Date.now(),
@@ -426,6 +447,7 @@ export class PluginService {
         error: null,
         validationErrors: [],
         moduleHash: opts?.moduleHash ?? null,
+        declaredDependencies,
       });
 
       this.deps.log.debug(`Plugin "${pluginId}" ready after retry`, { plugin: pluginId, retryCount });
@@ -789,6 +811,12 @@ export class PluginService {
             { pluginId, cycles },
           );
         }
+
+        // Advisory missing dependency warnings
+        const depWarnings = this.getDependencyWarnings(pluginId);
+        for (const w of depWarnings) {
+          this.deps.log.warn(w, { pluginId });
+        }
       }
 
       this.transition(pluginId, 'ready', {
@@ -885,6 +913,19 @@ export class PluginService {
       this.dependencyAnalyzer.removePlugin(pluginId);
       if (declaredDependencies) {
         this.dependencyAnalyzer.addPlugin(pluginId, declaredDependencies);
+
+        const cycles = this.dependencyAnalyzer.detectCycles();
+        if (cycles.length > 0) {
+          this.deps.log.warn(
+            `Dependency cycle detected after reloading "${pluginId}": ${cycles.map((c) => c.join(' → ')).join('; ')}`,
+            { pluginId, cycles },
+          );
+        }
+
+        const depWarnings = this.getDependencyWarnings(pluginId);
+        for (const w of depWarnings) {
+          this.deps.log.warn(w, { pluginId });
+        }
       }
 
       // Atomic swap
@@ -1027,13 +1068,16 @@ export class PluginService {
     const epIdSet = new Set(extensionPointIds);
 
     // Replay from pending map first (so pending contributions get priority)
-    const replayedContributionIds = new Set<string>();
+    // Key by extensionPointId:contributionId to allow the same contributionId
+    // across different extension points.
+    const replayedKeys = new Set<string>();
     for (const epId of extensionPointIds) {
       const pending = this.pendingContributionsByExtensionPoint.get(epId);
       if (!pending || pending.length === 0) continue;
 
       const remaining: NormalizedContribution[] = [];
       for (const c of pending) {
+        const dedupeKey = `${c.extensionPointId}:${c.contributionId}`;
         try {
           this.deps.registerContribution(c.extensionPointId, {
             id: c.contributionId,
@@ -1042,7 +1086,7 @@ export class PluginService {
             value: c.value,
             meta: c.meta,
           });
-          replayedContributionIds.add(c.contributionId);
+          replayedKeys.add(dedupeKey);
           this.deps.log.debug(
             `Replayed pending contribution "${c.contributionId}" to "${c.extensionPointId}"`,
             { pluginId: c.pluginId, contributionId: c.contributionId, extensionPointId: c.extensionPointId },
@@ -1050,6 +1094,12 @@ export class PluginService {
         } catch (err) {
           if (err instanceof MissingExtensionPointError) {
             remaining.push(c);
+          } else if (err instanceof DuplicateContributionError) {
+            // Stale duplicate — discard from pending, do not keep in remaining
+            this.deps.log.debug(
+              `Discarded stale duplicate pending contribution "${c.contributionId}" for "${c.extensionPointId}"`,
+              { pluginId: c.pluginId, contributionId: c.contributionId, extensionPointId: c.extensionPointId },
+            );
           } else {
             throw err;
           }
@@ -1071,7 +1121,8 @@ export class PluginService {
       if (!pluginState || pluginState.phase !== 'ready') continue;
 
       for (const c of contributions) {
-        if (epIdSet.has(c.extensionPointId) && !replayedContributionIds.has(c.contributionId)) {
+        const dedupeKey = `${c.extensionPointId}:${c.contributionId}`;
+        if (epIdSet.has(c.extensionPointId) && !replayedKeys.has(dedupeKey)) {
           try {
             this.deps.registerContribution(c.extensionPointId, {
               id: c.contributionId,

--- a/ui/features/plugins/core/PluginService.ts
+++ b/ui/features/plugins/core/PluginService.ts
@@ -112,7 +112,14 @@ export class PluginService {
           { pluginId: info.pluginId, contributionId: info.contributionId, extensionPointId: info.extensionPointId },
         );
         for (const listener of this.quarantineListeners) {
-          listener(info);
+          try {
+            listener(info);
+          } catch (err) {
+            this.deps.log.error(
+              `Quarantine listener threw for "${info.contributionId}"`,
+              { pluginId: info.pluginId, contributionId: info.contributionId, error: err instanceof Error ? err.message : String(err) },
+            );
+          }
         }
       },
     });
@@ -156,8 +163,12 @@ export class PluginService {
     return this.routeVersion;
   }
 
-  getPendingContributions(): ReadonlyMap<string, NormalizedContribution[]> {
-    return new Map(this.pendingContributionsByExtensionPoint);
+  getPendingContributions(): ReadonlyMap<string, readonly NormalizedContribution[]> {
+    const result = new Map<string, readonly NormalizedContribution[]>();
+    for (const [key, arr] of this.pendingContributionsByExtensionPoint) {
+      result.set(key, [...arr]);
+    }
+    return result;
   }
 
   // ── Quarantine API ────────────────────────────────────────────────
@@ -205,20 +216,17 @@ export class PluginService {
 
   recordContributionCrash(record: CrashRecord): void {
     this.deps.crashData.recordCrash(record);
-    const wasBefore = this.quarantineManager.isQuarantined(record.contributionId);
     this.quarantineManager.checkAndQuarantine(
       record.contributionId,
       record.pluginId,
       record.extensionPointId,
     );
-    // Notify subscribers so UI re-renders when quarantine state changes
-    if (!wasBefore && this.quarantineManager.isQuarantined(record.contributionId)) {
-      this.notify();
-    }
+    this.notify();
   }
 
   recordBoundaryCrash(record: CrashRecord): void {
     this.deps.crashData.recordCrash(record);
+    this.notify();
   }
 
   getCrashCount(contributionId: string): number {
@@ -530,6 +538,7 @@ export class PluginService {
           error: null,
           validationErrors: [],
           moduleHash: p.moduleHash,
+          declaredDependencies: p.declaredDependencies,
         });
 
         readyCount++;
@@ -542,10 +551,13 @@ export class PluginService {
       }
     }
 
-    // Replay pending contributions for all newly registered EPs in this batch.
+    // Replay pending contributions only for EPs from plugins that reached ready.
     const allNewEpIds: string[] = [];
     for (const p of prepared) {
-      allNewEpIds.push(...p.extensionPoints.map((ep) => ep.id));
+      const ps = this.state.get(p.pluginId);
+      if (ps?.phase === 'ready') {
+        allNewEpIds.push(...p.extensionPoints.map((ep) => ep.id));
+      }
     }
     if (allNewEpIds.length > 0) {
       this.replayContributionsForExtensionPoints(allNewEpIds);
@@ -565,6 +577,16 @@ export class PluginService {
         `Dependency cycle detected among plugins: ${cycles.map((c) => c.join(' -> ')).join('; ')}`,
         { cycles },
       );
+    }
+
+    // Emit missing dependency advisories
+    for (const p of prepared) {
+      if (p.declaredDependencies) {
+        const warnings = this.getDependencyWarnings(p.pluginId);
+        for (const w of warnings) {
+          this.deps.log.warn(w, { pluginId: p.pluginId });
+        }
+      }
     }
 
     // Count plugins that failed during prepare (not in prepared array)
@@ -1057,10 +1079,12 @@ export class PluginService {
               value: c.value,
               meta: c.meta,
             });
-          } catch {
-            // Expected: MissingExtensionPointError (EP removed again) or
-            // duplicate registration (contribution already registered during
-            // initial applyContributions in this batch). Both are harmless.
+          } catch (err) {
+            // Tolerate MissingExtensionPointError (EP removed) and duplicate
+            // registration (contribution already registered during applyContributions).
+            if (err instanceof MissingExtensionPointError) continue;
+            if (err instanceof Error && err.message.includes('already exists')) continue;
+            throw err;
           }
         }
       }
@@ -1230,6 +1254,9 @@ export class PluginService {
       plugin: pluginId,
       error: message,
     });
+
+    // Clean up any pending contributions queued during the failed load
+    this.removePluginPendingContributions(pluginId);
 
     // Transition to error, preserving existing state fields
     const current = this.state.get(pluginId);

--- a/ui/features/plugins/core/PluginService.ts
+++ b/ui/features/plugins/core/PluginService.ts
@@ -7,6 +7,7 @@ import {
   PluginValidationError,
   PluginTimeoutError,
   MissingExtensionPointError,
+  DuplicateContributionError,
 } from './errors';
 import type {
   PluginPhase,
@@ -1083,7 +1084,7 @@ export class PluginService {
             // Tolerate MissingExtensionPointError (EP removed) and duplicate
             // registration (contribution already registered during applyContributions).
             if (err instanceof MissingExtensionPointError) continue;
-            if (err instanceof Error && err.message.includes('already exists')) continue;
+            if (err instanceof DuplicateContributionError) continue;
             throw err;
           }
         }

--- a/ui/features/plugins/core/PluginService.ts
+++ b/ui/features/plugins/core/PluginService.ts
@@ -1,9 +1,12 @@
 import type { RouteObject } from 'react-router-dom';
 import { assertValidTransition } from './transitions';
-import { normalizeContributions } from './normalization';
+import { normalizeContributions, extractDeclaredDependencies } from './normalization';
+import { DependencyAnalyzer } from './DependencyAnalyzer';
+import { QuarantineManager } from './QuarantineManager';
 import {
   PluginValidationError,
   PluginTimeoutError,
+  MissingExtensionPointError,
 } from './errors';
 import type {
   PluginPhase,
@@ -22,6 +25,10 @@ import type {
   PluginDescriptor,
   PluginLoadOpts,
   ExtensionPointSettings,
+  DeclaredDependencies,
+  QuarantineInfo,
+  DependencyGraph,
+  CrashRecord,
 } from './types';
 import { DEFAULT_CONFIG } from './types';
 
@@ -76,6 +83,11 @@ export class PluginService {
   // Contribution replay storage
   private normalizedContributionsByPlugin = new Map<string, NormalizedContribution[]>();
   private definedExtensionPointIdsByPlugin = new Map<string, string[]>();
+  private pendingContributionsByExtensionPoint = new Map<string, NormalizedContribution[]>();
+
+  private readonly dependencyAnalyzer = new DependencyAnalyzer();
+  private readonly quarantineManager: QuarantineManager;
+  private readonly quarantineListeners = new Set<(info: QuarantineInfo) => void>();
 
   // Snapshot memoization
   private cachedSnapshot: PluginServiceSnapshot | null = null;
@@ -91,6 +103,19 @@ export class PluginService {
   constructor(deps: PluginServiceDeps, config?: Partial<PluginServiceConfig>) {
     this.deps = deps;
     this.config = { ...DEFAULT_CONFIG, ...config };
+    this.quarantineManager = new QuarantineManager({
+      crashData: deps.crashData,
+      threshold: this.config.quarantineCrashThreshold,
+      onQuarantine: (info) => {
+        this.deps.log.warn(
+          `Contribution "${info.contributionId}" quarantined after ${info.crashCount} crashes`,
+          { pluginId: info.pluginId, contributionId: info.contributionId, extensionPointId: info.extensionPointId },
+        );
+        for (const listener of this.quarantineListeners) {
+          listener(info);
+        }
+      },
+    });
   }
 
   // ── Queries ─────────────────────────────────────────────────────
@@ -131,6 +156,75 @@ export class PluginService {
     return this.routeVersion;
   }
 
+  getPendingContributions(): ReadonlyMap<string, NormalizedContribution[]> {
+    return new Map(this.pendingContributionsByExtensionPoint);
+  }
+
+  // ── Quarantine API ────────────────────────────────────────────────
+
+  isQuarantined(contributionId: string): boolean {
+    return this.quarantineManager.isQuarantined(contributionId);
+  }
+
+  unquarantine(contributionId: string): void {
+    this.quarantineManager.unquarantine(contributionId);
+    this.notify();
+  }
+
+  listQuarantined(): QuarantineInfo[] {
+    return this.quarantineManager.listQuarantined();
+  }
+
+  onQuarantineActivated(listener: (info: QuarantineInfo) => void): () => void {
+    this.quarantineListeners.add(listener);
+    return () => { this.quarantineListeners.delete(listener); };
+  }
+
+  // ── Dependency API ────────────────────────────────────────────────
+
+  getDependencyWarnings(pluginId: string): string[] {
+    const loadedPlugins = new Set<string>();
+    const registeredEPs = new Set<string>();
+    for (const [id, s] of this.state) {
+      if (s.phase === 'ready') {
+        loadedPlugins.add(id);
+        const epIds = this.definedExtensionPointIdsByPlugin.get(id);
+        if (epIds) {
+          for (const epId of epIds) registeredEPs.add(epId);
+        }
+      }
+    }
+    return this.dependencyAnalyzer.checkMissingDependencies(pluginId, loadedPlugins, registeredEPs);
+  }
+
+  getDependencyGraph(): DependencyGraph {
+    return this.dependencyAnalyzer.getGraph();
+  }
+
+  // ── Crash Data API ────────────────────────────────────────────────
+
+  recordContributionCrash(record: CrashRecord): void {
+    this.deps.crashData.recordCrash(record);
+    const wasBefore = this.quarantineManager.isQuarantined(record.contributionId);
+    this.quarantineManager.checkAndQuarantine(
+      record.contributionId,
+      record.pluginId,
+      record.extensionPointId,
+    );
+    // Notify subscribers so UI re-renders when quarantine state changes
+    if (!wasBefore && this.quarantineManager.isQuarantined(record.contributionId)) {
+      this.notify();
+    }
+  }
+
+  recordBoundaryCrash(record: CrashRecord): void {
+    this.deps.crashData.recordCrash(record);
+  }
+
+  getCrashCount(contributionId: string): number {
+    return this.deps.crashData.getCrashCount(contributionId);
+  }
+
   getDebugSnapshot(): PluginServiceDebugSnapshot {
     const plugins: Record<string, PluginServiceDebugPluginState> = {};
 
@@ -141,6 +235,7 @@ export class PluginService {
         contributedExtensionPoints: this.getContributedExtensionPointIds(id),
         contributions: this.getContributionDebugRecords(id),
         definedExtensionPoints: this.getDefinedExtensionPointIds(id),
+        dependencyWarnings: this.getDependencyWarnings(id),
       };
     }
 
@@ -150,6 +245,9 @@ export class PluginService {
       ready: this.ready,
       routeVersion: this.routeVersion,
       eventListenersActive: this.eventCleanups.length > 0,
+      pendingContributions: this.getPendingContributionsDebug(),
+      quarantinedContributions: this.quarantineManager.listQuarantined(),
+      recentCrashes: this.getRecentCrashes(),
     };
   }
 
@@ -444,6 +542,31 @@ export class PluginService {
       }
     }
 
+    // Replay pending contributions for all newly registered EPs in this batch.
+    const allNewEpIds: string[] = [];
+    for (const p of prepared) {
+      allNewEpIds.push(...p.extensionPoints.map((ep) => ep.id));
+    }
+    if (allNewEpIds.length > 0) {
+      this.replayContributionsForExtensionPoints(allNewEpIds);
+    }
+
+    // F1: Register dependency metadata and run diagnostics
+    for (const p of prepared) {
+      if (p.declaredDependencies) {
+        this.dependencyAnalyzer.addPlugin(p.pluginId, p.declaredDependencies);
+      }
+    }
+
+    // Check for cycles after all plugins loaded
+    const cycles = this.dependencyAnalyzer.detectCycles();
+    if (cycles.length > 0) {
+      this.deps.log.warn(
+        `Dependency cycle detected among plugins: ${cycles.map((c) => c.join(' -> ')).join('; ')}`,
+        { cycles },
+      );
+    }
+
     // Count plugins that failed during prepare (not in prepared array)
     failedCount += toLoad.length - prepared.length;
 
@@ -558,8 +681,13 @@ export class PluginService {
     this.inflightLoads.clear();
     this.normalizedContributionsByPlugin.clear();
     this.definedExtensionPointIdsByPlugin.clear();
+    this.pendingContributionsByExtensionPoint.clear();
     this.loadGeneration.clear();
     this.legacyWarningEmitted.clear();
+    this.quarantineManager.clearAll();
+    this.deps.crashData.clearAll();
+    this.dependencyAnalyzer.clear();
+    // Note: quarantineListeners are NOT cleared — Provider subscriptions persist across reset
     this.cachedSnapshot = null;
     this.cachedRoutes = null;
     this.ready = false;
@@ -601,6 +729,8 @@ export class PluginService {
       if (!this.isCurrentGeneration(pluginId, generation)) return;
 
       const validated = this.deps.validateExports(rawModule);
+      const rawDeps = (rawModule as Record<string, unknown>)?.dependencies;
+      const declaredDependencies = extractDeclaredDependencies(rawDeps);
       const normalizedContributions = normalizeContributions(pluginId, validated);
       const extensionPoints = this.extractExtensionPoints(validated);
       const registrationsObj = this.buildRegistrations(validated);
@@ -624,6 +754,20 @@ export class PluginService {
         { excludePluginId: pluginId },
       );
 
+      // F1: Store and analyze dependencies
+      if (declaredDependencies) {
+        this.dependencyAnalyzer.addPlugin(pluginId, declaredDependencies);
+
+        // Advisory cycle detection — log but never block
+        const cycles = this.dependencyAnalyzer.detectCycles();
+        if (cycles.length > 0) {
+          this.deps.log.warn(
+            `Dependency cycle detected after loading "${pluginId}": ${cycles.map((c) => c.join(' → ')).join('; ')}`,
+            { pluginId, cycles },
+          );
+        }
+      }
+
       this.transition(pluginId, 'ready', {
         pluginWindow: validated.plugin,
         loadedAt: Date.now(),
@@ -633,6 +777,7 @@ export class PluginService {
         error: null,
         validationErrors: [],
         moduleHash: opts.moduleHash ?? null,
+        declaredDependencies,
       });
 
       this.deps.log.debug(`Plugin "${pluginId}" ready`, { plugin: pluginId });
@@ -679,13 +824,20 @@ export class PluginService {
       if (!this.isCurrentGeneration(pluginId, generation)) return;
 
       const validated = this.deps.validateExports(rawModule);
+      const rawDeps = (rawModule as Record<string, unknown>)?.dependencies;
+      const declaredDependencies = extractDeclaredDependencies(rawDeps);
       const normalizedContributions = normalizeContributions(pluginId, validated);
       const extensionPoints = this.extractExtensionPoints(validated);
       const registrationsObj = this.buildRegistrations(validated);
 
-      // Remove old registrations before applying new ones
+      // F2: Clear quarantine and crash data for reloading plugin
+      this.quarantineManager.clearForPlugin(pluginId);
+      this.deps.crashData.clearForPlugin(pluginId);
+
+      // Remove old registrations and pending contributions before applying new ones
       this.deps.removeContributions(pluginId);
       this.deps.removeExtensionPoints(pluginId);
+      this.removePluginPendingContributions(pluginId);
 
       // Register new extension points
       this.registerExtensionPoints(pluginId, extensionPoints);
@@ -706,6 +858,12 @@ export class PluginService {
         { excludePluginId: pluginId },
       );
 
+      // F1: Update dependency data (remove stale edges first)
+      this.dependencyAnalyzer.removePlugin(pluginId);
+      if (declaredDependencies) {
+        this.dependencyAnalyzer.addPlugin(pluginId, declaredDependencies);
+      }
+
       // Atomic swap
       this.transition(pluginId, 'ready', {
         pluginWindow: validated.plugin,
@@ -716,6 +874,7 @@ export class PluginService {
         error: null,
         validationErrors: [],
         moduleHash: opts?.moduleHash ?? null,
+        declaredDependencies,
       });
 
       this.deps.log.debug(`Plugin "${pluginId}" reloaded successfully`, { plugin: pluginId });
@@ -773,6 +932,8 @@ export class PluginService {
       }));
 
       const validated = this.deps.validateExports(rawModule);
+      const rawDeps = (rawModule as Record<string, unknown>)?.dependencies;
+      const declaredDependencies = extractDeclaredDependencies(rawDeps);
       const normalizedContributions = normalizeContributions(pluginId, validated);
       const extensionPoints = this.extractExtensionPoints(validated);
       const registrationsObj = this.buildRegistrations(validated);
@@ -787,6 +948,7 @@ export class PluginService {
         isDev,
         devPort,
         moduleHash,
+        declaredDependencies,
       };
     } catch (err) {
       this.handleLoadError(pluginId, err, 0);
@@ -808,13 +970,28 @@ export class PluginService {
     contributions: NormalizedContribution[],
   ): void {
     for (const c of contributions) {
-      this.deps.registerContribution(c.extensionPointId, {
-        id: c.contributionId,
-        plugin: pluginId,
-        label: c.label,
-        value: c.value,
-        meta: c.meta,
-      });
+      try {
+        this.deps.registerContribution(c.extensionPointId, {
+          id: c.contributionId,
+          plugin: pluginId,
+          label: c.label,
+          value: c.value,
+          meta: c.meta,
+        });
+      } catch (err) {
+        if (err instanceof MissingExtensionPointError) {
+          const pending = this.pendingContributionsByExtensionPoint.get(c.extensionPointId) ?? [];
+          pending.push(c);
+          this.pendingContributionsByExtensionPoint.set(c.extensionPointId, pending);
+
+          this.deps.log.debug(
+            `Contribution "${c.contributionId}" held pending — extension point "${c.extensionPointId}" not yet registered`,
+            { pluginId, contributionId: c.contributionId, extensionPointId: c.extensionPointId },
+          );
+        } else {
+          throw err;
+        }
+      }
     }
   }
 
@@ -826,15 +1003,52 @@ export class PluginService {
 
     const epIdSet = new Set(extensionPointIds);
 
+    // Replay from pending map first (so pending contributions get priority)
+    const replayedContributionIds = new Set<string>();
+    for (const epId of extensionPointIds) {
+      const pending = this.pendingContributionsByExtensionPoint.get(epId);
+      if (!pending || pending.length === 0) continue;
+
+      const remaining: NormalizedContribution[] = [];
+      for (const c of pending) {
+        try {
+          this.deps.registerContribution(c.extensionPointId, {
+            id: c.contributionId,
+            plugin: c.pluginId,
+            label: c.label,
+            value: c.value,
+            meta: c.meta,
+          });
+          replayedContributionIds.add(c.contributionId);
+          this.deps.log.debug(
+            `Replayed pending contribution "${c.contributionId}" to "${c.extensionPointId}"`,
+            { pluginId: c.pluginId, contributionId: c.contributionId, extensionPointId: c.extensionPointId },
+          );
+        } catch (err) {
+          if (err instanceof MissingExtensionPointError) {
+            remaining.push(c);
+          } else {
+            throw err;
+          }
+        }
+      }
+
+      if (remaining.length === 0) {
+        this.pendingContributionsByExtensionPoint.delete(epId);
+      } else {
+        this.pendingContributionsByExtensionPoint.set(epId, remaining);
+      }
+    }
+
+    // Replay from normalizedContributionsByPlugin (existing behavior)
     for (const [pid, contributions] of this.normalizedContributionsByPlugin) {
       if (opts?.excludePluginId && pid === opts.excludePluginId) continue;
 
-      // Only replay for plugins that are in ready state
       const pluginState = this.state.get(pid);
       if (!pluginState || pluginState.phase !== 'ready') continue;
 
       for (const c of contributions) {
-        if (epIdSet.has(c.extensionPointId)) {
+        if (epIdSet.has(c.extensionPointId) && !replayedContributionIds.has(c.contributionId)) {
           try {
             this.deps.registerContribution(c.extensionPointId, {
               id: c.contributionId,
@@ -843,12 +1057,10 @@ export class PluginService {
               value: c.value,
               meta: c.meta,
             });
-          } catch (e) {
-            // Extension point may have been removed again — log for debugging
-            console.debug(
-              `[PluginService] replay: failed to register contribution "${c.contributionId}" → EP "${c.extensionPointId}" (plugin "${pid}")`,
-              e,
-            );
+          } catch {
+            // Expected: MissingExtensionPointError (EP removed again) or
+            // duplicate registration (contribution already registered during
+            // initial applyContributions in this batch). Both are harmless.
           }
         }
       }
@@ -861,6 +1073,21 @@ export class PluginService {
     this.registrations.delete(pluginId);
     this.normalizedContributionsByPlugin.delete(pluginId);
     this.definedExtensionPointIdsByPlugin.delete(pluginId);
+    this.removePluginPendingContributions(pluginId);
+    this.quarantineManager.clearForPlugin(pluginId);
+    this.deps.crashData.clearForPlugin(pluginId);
+    this.dependencyAnalyzer.removePlugin(pluginId);
+  }
+
+  private removePluginPendingContributions(pluginId: string): void {
+    for (const [epId, contributions] of this.pendingContributionsByExtensionPoint) {
+      const filtered = contributions.filter((c) => c.pluginId !== pluginId);
+      if (filtered.length === 0) {
+        this.pendingContributionsByExtensionPoint.delete(epId);
+      } else {
+        this.pendingContributionsByExtensionPoint.set(epId, filtered);
+      }
+    }
   }
 
   private buildRegistrations(validated: ValidatedExports): PluginRegistrations {
@@ -1076,12 +1303,45 @@ export class PluginService {
   private getContributionDebugRecords(pluginId: string): PluginDebugContributionRecord[] {
     const contributions = this.normalizedContributionsByPlugin.get(pluginId);
     if (!contributions) return [];
-    return contributions.map((c) => ({
-      id: c.contributionId,
-      extensionPointId: c.extensionPointId,
-      source: c.source,
-      resourceKey: (c.meta as { resourceKey?: string })?.resourceKey,
-    }));
+    return contributions.map((c) => {
+      const pendingList = this.pendingContributionsByExtensionPoint.get(c.extensionPointId);
+      const isPending = pendingList?.some((p) => p.contributionId === c.contributionId) ?? false;
+
+      return {
+        id: c.contributionId,
+        extensionPointId: c.extensionPointId,
+        source: c.source,
+        resourceKey: (c.meta as { resourceKey?: string })?.resourceKey,
+        status: isPending
+          ? 'pending' as const
+          : this.quarantineManager.isQuarantined(c.contributionId)
+            ? 'quarantined' as const
+            : 'applied' as const,
+        crashCount: this.deps.crashData.getCrashCount(c.contributionId),
+      };
+    });
+  }
+
+  private getPendingContributionsDebug(): Record<string, { pluginId: string; contributionId: string; extensionPointId: string }[]> {
+    const result: Record<string, { pluginId: string; contributionId: string; extensionPointId: string }[]> = {};
+    for (const [epId, contributions] of this.pendingContributionsByExtensionPoint) {
+      result[epId] = contributions.map((c) => ({
+        pluginId: c.pluginId,
+        contributionId: c.contributionId,
+        extensionPointId: c.extensionPointId,
+      }));
+    }
+    return result;
+  }
+
+  private getRecentCrashes(): CrashRecord[] {
+    const allHistory = this.deps.crashData.getAllCrashHistory();
+    const all: CrashRecord[] = [];
+    for (const records of allHistory.values()) {
+      all.push(...records);
+    }
+    all.sort((a, b) => b.timestamp - a.timestamp);
+    return all.slice(0, 50);
   }
 
   private getDefinedExtensionPointIds(pluginId: string): string[] {

--- a/ui/features/plugins/core/QuarantineManager.test.ts
+++ b/ui/features/plugins/core/QuarantineManager.test.ts
@@ -83,6 +83,8 @@ describe('QuarantineManager', () => {
       manager.clearForPlugin('plugin-a');
       expect(manager.isQuarantined('c1')).toBe(false);
       expect(manager.isQuarantined('c2')).toBe(false);
+      expect(crashData.getCrashCount('c1')).toBe(0);
+      expect(crashData.getCrashCount('c2')).toBe(0);
     });
 
     it('does not affect other plugins', () => {
@@ -111,6 +113,8 @@ describe('QuarantineManager', () => {
       manager.clearAll();
       expect(manager.isQuarantined('c1')).toBe(false);
       expect(manager.isQuarantined('c2')).toBe(false);
+      expect(crashData.getCrashCount('c1')).toBe(0);
+      expect(crashData.getCrashCount('c2')).toBe(0);
     });
   });
 

--- a/ui/features/plugins/core/QuarantineManager.test.ts
+++ b/ui/features/plugins/core/QuarantineManager.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi } from 'vitest';
+import { QuarantineManager } from './QuarantineManager';
+import { InMemoryCrashDataStrategy } from './CrashDataService';
+import type { CrashRecord } from './types';
+
+function makeCrashRecord(overrides?: Partial<CrashRecord>): CrashRecord {
+  return {
+    contributionId: 'plugin-a/sidebar/res',
+    pluginId: 'plugin-a',
+    extensionPointId: 'omniview/resource/sidebar/infopanel',
+    boundary: 'ExtensionPointRenderer',
+    errorMessage: 'crash',
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+function createTestSetup(threshold = 3) {
+  const crashData = new InMemoryCrashDataStrategy({ maxRecordsPerContribution: 10 });
+  const onQuarantine = vi.fn();
+  const manager = new QuarantineManager({ crashData, threshold, onQuarantine });
+  return { crashData, onQuarantine, manager };
+}
+
+describe('QuarantineManager', () => {
+  describe('checkAndQuarantine', () => {
+    it('does not quarantine below threshold', () => {
+      const { crashData, manager } = createTestSetup(3);
+      crashData.recordCrash(makeCrashRecord());
+      crashData.recordCrash(makeCrashRecord());
+      manager.checkAndQuarantine('plugin-a/sidebar/res', 'plugin-a', 'omniview/resource/sidebar/infopanel');
+      expect(manager.isQuarantined('plugin-a/sidebar/res')).toBe(false);
+    });
+
+    it('quarantines at threshold', () => {
+      const { crashData, manager } = createTestSetup(3);
+      for (let i = 0; i < 3; i++) crashData.recordCrash(makeCrashRecord());
+      manager.checkAndQuarantine('plugin-a/sidebar/res', 'plugin-a', 'omniview/resource/sidebar/infopanel');
+      expect(manager.isQuarantined('plugin-a/sidebar/res')).toBe(true);
+    });
+
+    it('emits onQuarantine callback when quarantine activates', () => {
+      const { crashData, manager, onQuarantine } = createTestSetup(3);
+      for (let i = 0; i < 3; i++) crashData.recordCrash(makeCrashRecord());
+      manager.checkAndQuarantine('plugin-a/sidebar/res', 'plugin-a', 'omniview/resource/sidebar/infopanel');
+      expect(onQuarantine).toHaveBeenCalledTimes(1);
+      expect(onQuarantine).toHaveBeenCalledWith(expect.objectContaining({
+        contributionId: 'plugin-a/sidebar/res',
+        pluginId: 'plugin-a',
+        extensionPointId: 'omniview/resource/sidebar/infopanel',
+      }));
+    });
+
+    it('does not emit again if already quarantined', () => {
+      const { crashData, manager, onQuarantine } = createTestSetup(3);
+      for (let i = 0; i < 4; i++) crashData.recordCrash(makeCrashRecord());
+      manager.checkAndQuarantine('plugin-a/sidebar/res', 'plugin-a', 'omniview/resource/sidebar/infopanel');
+      manager.checkAndQuarantine('plugin-a/sidebar/res', 'plugin-a', 'omniview/resource/sidebar/infopanel');
+      expect(onQuarantine).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('unquarantine', () => {
+    it('removes quarantine and resets crash count', () => {
+      const { crashData, manager } = createTestSetup(3);
+      for (let i = 0; i < 3; i++) crashData.recordCrash(makeCrashRecord());
+      manager.checkAndQuarantine('plugin-a/sidebar/res', 'plugin-a', 'omniview/resource/sidebar/infopanel');
+      manager.unquarantine('plugin-a/sidebar/res');
+      expect(manager.isQuarantined('plugin-a/sidebar/res')).toBe(false);
+      expect(crashData.getCrashCount('plugin-a/sidebar/res')).toBe(0);
+    });
+  });
+
+  describe('clearForPlugin', () => {
+    it('clears quarantine for all contributions of a plugin', () => {
+      const { crashData, manager } = createTestSetup(3);
+      for (let i = 0; i < 3; i++) {
+        crashData.recordCrash(makeCrashRecord({ contributionId: 'c1', pluginId: 'plugin-a' }));
+        crashData.recordCrash(makeCrashRecord({ contributionId: 'c2', pluginId: 'plugin-a' }));
+      }
+      manager.checkAndQuarantine('c1', 'plugin-a', 'ep1');
+      manager.checkAndQuarantine('c2', 'plugin-a', 'ep1');
+      manager.clearForPlugin('plugin-a');
+      expect(manager.isQuarantined('c1')).toBe(false);
+      expect(manager.isQuarantined('c2')).toBe(false);
+    });
+
+    it('does not affect other plugins', () => {
+      const { crashData, manager } = createTestSetup(3);
+      for (let i = 0; i < 3; i++) {
+        crashData.recordCrash(makeCrashRecord({ contributionId: 'c1', pluginId: 'plugin-a' }));
+        crashData.recordCrash(makeCrashRecord({ contributionId: 'c2', pluginId: 'plugin-b' }));
+      }
+      manager.checkAndQuarantine('c1', 'plugin-a', 'ep1');
+      manager.checkAndQuarantine('c2', 'plugin-b', 'ep1');
+      manager.clearForPlugin('plugin-a');
+      expect(manager.isQuarantined('c1')).toBe(false);
+      expect(manager.isQuarantined('c2')).toBe(true);
+    });
+  });
+
+  describe('clearAll', () => {
+    it('clears all quarantine state', () => {
+      const { crashData, manager } = createTestSetup(3);
+      for (let i = 0; i < 3; i++) {
+        crashData.recordCrash(makeCrashRecord({ contributionId: 'c1' }));
+        crashData.recordCrash(makeCrashRecord({ contributionId: 'c2' }));
+      }
+      manager.checkAndQuarantine('c1', 'plugin-a', 'ep1');
+      manager.checkAndQuarantine('c2', 'plugin-a', 'ep1');
+      manager.clearAll();
+      expect(manager.isQuarantined('c1')).toBe(false);
+      expect(manager.isQuarantined('c2')).toBe(false);
+    });
+  });
+
+  describe('listQuarantined', () => {
+    it('returns all quarantined contributions', () => {
+      const { crashData, manager } = createTestSetup(3);
+      for (let i = 0; i < 3; i++) {
+        crashData.recordCrash(makeCrashRecord({ contributionId: 'c1', pluginId: 'plugin-a' }));
+      }
+      manager.checkAndQuarantine('c1', 'plugin-a', 'ep1');
+      const list = manager.listQuarantined();
+      expect(list).toHaveLength(1);
+      expect(list[0]).toMatchObject({
+        contributionId: 'c1',
+        pluginId: 'plugin-a',
+        extensionPointId: 'ep1',
+        crashCount: 3,
+      });
+    });
+
+    it('returns empty array when nothing is quarantined', () => {
+      const { manager } = createTestSetup(3);
+      expect(manager.listQuarantined()).toEqual([]);
+    });
+  });
+
+  describe('isQuarantined', () => {
+    it('returns false for unknown contribution', () => {
+      const { manager } = createTestSetup(3);
+      expect(manager.isQuarantined('unknown')).toBe(false);
+    });
+  });
+});

--- a/ui/features/plugins/core/QuarantineManager.ts
+++ b/ui/features/plugins/core/QuarantineManager.ts
@@ -1,0 +1,76 @@
+import type { CrashDataStrategy, QuarantineInfo } from './types';
+
+interface QuarantineEntry {
+  readonly pluginId: string;
+  readonly extensionPointId: string;
+  readonly quarantinedAt: number;
+}
+
+export interface QuarantineManagerConfig {
+  readonly crashData: CrashDataStrategy;
+  readonly threshold: number;
+  readonly onQuarantine: (info: QuarantineInfo) => void;
+}
+
+export class QuarantineManager {
+  private readonly crashData: CrashDataStrategy;
+  private readonly threshold: number;
+  private readonly onQuarantine: (info: QuarantineInfo) => void;
+  private readonly quarantined = new Map<string, QuarantineEntry>();
+
+  constructor(config: QuarantineManagerConfig) {
+    if (!Number.isInteger(config.threshold) || config.threshold < 1) {
+      throw new Error(`QuarantineManager threshold must be a positive integer, got ${config.threshold}`);
+    }
+    this.crashData = config.crashData;
+    this.threshold = config.threshold;
+    this.onQuarantine = config.onQuarantine;
+  }
+
+  checkAndQuarantine(contributionId: string, pluginId: string, extensionPointId: string): void {
+    if (this.quarantined.has(contributionId)) return;
+    const count = this.crashData.getCrashCount(contributionId);
+    if (count < this.threshold) return;
+    const entry: QuarantineEntry = { pluginId, extensionPointId, quarantinedAt: Date.now() };
+    this.quarantined.set(contributionId, entry);
+    this.onQuarantine({ contributionId, pluginId, extensionPointId, crashCount: count, quarantinedAt: entry.quarantinedAt });
+  }
+
+  isQuarantined(contributionId: string): boolean {
+    return this.quarantined.has(contributionId);
+  }
+
+  unquarantine(contributionId: string): void {
+    if (this.quarantined.delete(contributionId)) {
+      this.crashData.clearForContribution(contributionId);
+    }
+  }
+
+  clearForPlugin(pluginId: string): void {
+    for (const [id, entry] of this.quarantined) {
+      if (entry.pluginId === pluginId) {
+        this.unquarantine(id);
+      }
+    }
+  }
+
+  clearAll(): void {
+    for (const id of [...this.quarantined.keys()]) {
+      this.unquarantine(id);
+    }
+  }
+
+  listQuarantined(): QuarantineInfo[] {
+    const result: QuarantineInfo[] = [];
+    for (const [id, entry] of this.quarantined) {
+      result.push({
+        contributionId: id,
+        pluginId: entry.pluginId,
+        extensionPointId: entry.extensionPointId,
+        crashCount: this.crashData.getCrashCount(id),
+        quarantinedAt: entry.quarantinedAt,
+      });
+    }
+    return result;
+  }
+}

--- a/ui/features/plugins/core/errors.ts
+++ b/ui/features/plugins/core/errors.ts
@@ -84,6 +84,25 @@ export class MissingExtensionPointError extends PluginServiceError {
 }
 
 /**
+ * Thrown when a contribution with the same ID is already registered
+ * in the target extension point.
+ */
+export class DuplicateContributionError extends PluginServiceError {
+  readonly extensionPointId: string;
+  readonly contributionId: string;
+
+  constructor(
+    message: string,
+    opts: { pluginId?: string; extensionPointId: string; contributionId: string; cause?: unknown },
+  ) {
+    super(message, { pluginId: opts.pluginId, cause: opts.cause });
+    this.name = 'DuplicateContributionError';
+    this.extensionPointId = opts.extensionPointId;
+    this.contributionId = opts.contributionId;
+  }
+}
+
+/**
  * Thrown when an extension point ID is already registered by another owner.
  */
 export class DuplicateExtensionPointError extends PluginServiceError {

--- a/ui/features/plugins/core/normalization.test.ts
+++ b/ui/features/plugins/core/normalization.test.ts
@@ -4,6 +4,7 @@ import {
   normalizeExtensionRegistration,
   normalizeLegacySidebar,
   normalizeLegacyDrawer,
+  extractDeclaredDependencies,
   RESOURCE_SIDEBAR_EXTENSION_POINT_ID,
   RESOURCE_DRAWER_EXTENSION_POINT_ID,
 } from './normalization';
@@ -186,7 +187,7 @@ describe('normalizeContributions', () => {
     expect(result.every((c) => c.source === 'legacy-sidebar')).toBe(true);
   });
 
-  it('consumers cannot distinguish contribution source', () => {
+  it('consumers cannot distinguish contribution source (Group 13.1 #6)', () => {
     // All contributions have the same NormalizedContribution shape
     const validated = makeValidated({
       extensionRegistrations: [
@@ -206,5 +207,46 @@ describe('normalizeContributions', () => {
       expect(c).toHaveProperty('value');
       expect(c).toHaveProperty('label');
     }
+  });
+});
+
+// ─── extractDeclaredDependencies ────────────────────────────────────
+
+describe('extractDeclaredDependencies', () => {
+  it('extracts full dependencies', () => {
+    const raw = {
+      plugins: ['plugin-a', 'plugin-b'],
+      extensionPoints: ['ep/1'],
+    };
+    const result = extractDeclaredDependencies(raw);
+    expect(result).toEqual({
+      plugins: ['plugin-a', 'plugin-b'],
+      extensionPoints: ['ep/1'],
+    });
+  });
+
+  it('defaults missing fields to empty arrays', () => {
+    const result = extractDeclaredDependencies({});
+    expect(result).toEqual({ plugins: [], extensionPoints: [] });
+  });
+
+  it('returns undefined for undefined input', () => {
+    const result = extractDeclaredDependencies(undefined);
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined for null input', () => {
+    const result = extractDeclaredDependencies(null);
+    expect(result).toBeUndefined();
+  });
+
+  it('defaults missing plugins to empty array', () => {
+    const result = extractDeclaredDependencies({ extensionPoints: ['ep/1'] });
+    expect(result).toEqual({ plugins: [], extensionPoints: ['ep/1'] });
+  });
+
+  it('defaults missing extensionPoints to empty array', () => {
+    const result = extractDeclaredDependencies({ plugins: ['p1'] });
+    expect(result).toEqual({ plugins: ['p1'], extensionPoints: [] });
   });
 });

--- a/ui/features/plugins/core/normalization.ts
+++ b/ui/features/plugins/core/normalization.ts
@@ -4,6 +4,7 @@ import type {
   SidebarComponent,
   DrawerFactory,
   ExtensionRegistration,
+  DeclaredDependencies,
 } from './types';
 
 // Re-export from canonical source for backwards compatibility with existing imports.
@@ -113,4 +114,20 @@ export function normalizeContributions(
   }
 
   return contributions;
+}
+
+/**
+ * Extract declared dependencies from raw plugin exports.
+ * Returns undefined if no dependencies field is present.
+ * Validation has already ensured correct shape.
+ */
+export function extractDeclaredDependencies(
+  raw: unknown,
+): DeclaredDependencies | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  const deps = raw as Record<string, unknown>;
+  return {
+    plugins: Array.isArray(deps.plugins) ? (deps.plugins as string[]) : [],
+    extensionPoints: Array.isArray(deps.extensionPoints) ? (deps.extensionPoints as string[]) : [],
+  };
 }

--- a/ui/features/plugins/core/normalization.ts
+++ b/ui/features/plugins/core/normalization.ts
@@ -117,9 +117,10 @@ export function normalizeContributions(
 }
 
 /**
- * Extract declared dependencies from raw plugin exports.
- * Returns undefined if no dependencies field is present.
- * Validation has already ensured correct shape.
+ * Extract declared dependencies from the nested dependencies object
+ * (i.e., rawModule.dependencies, not the full raw module).
+ * Returns undefined if the input is null/undefined.
+ * Validation has already ensured correct shape; arrays are shallow-cloned.
  */
 export function extractDeclaredDependencies(
   raw: unknown,
@@ -127,7 +128,7 @@ export function extractDeclaredDependencies(
   if (raw === undefined || raw === null) return undefined;
   const deps = raw as Record<string, unknown>;
   return {
-    plugins: Array.isArray(deps.plugins) ? (deps.plugins as string[]) : [],
-    extensionPoints: Array.isArray(deps.extensionPoints) ? (deps.extensionPoints as string[]) : [],
+    plugins: Array.isArray(deps.plugins) ? [...(deps.plugins as string[])] : [],
+    extensionPoints: Array.isArray(deps.extensionPoints) ? [...(deps.extensionPoints as string[])] : [],
   };
 }

--- a/ui/features/plugins/core/softResolution.test.ts
+++ b/ui/features/plugins/core/softResolution.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from 'vitest';
+import { PluginService } from './PluginService';
+import { createTestDeps } from '../testing/helpers';
+
+describe('Soft Contribution Resolution', () => {
+  describe('applyContributions holds pending contributions', () => {
+    it('holds contributions targeting missing EPs in pending map', async () => {
+      const { deps, importer } = createTestDeps();
+      const service = new PluginService(deps);
+
+      importer.register('plugin-a', {
+        plugin: { _routes: [] },
+        extensionRegistrations: [
+          {
+            extensionPointId: 'missing/ep',
+            registration: { id: 'contrib-1', label: 'C1', value: 'val', meta: undefined },
+          },
+        ],
+      });
+
+      await service.load('plugin-a');
+
+      expect(service.getPluginState('plugin-a')?.phase).toBe('ready');
+      const pending = service.getPendingContributions();
+      expect(pending.get('missing/ep')).toHaveLength(1);
+    });
+
+    it('applies non-missing EP contributions normally while holding missing ones', async () => {
+      const { deps, importer, extensions } = createTestDeps();
+      const service = new PluginService(deps);
+
+      extensions.addExtensionPoint({ id: 'existing/ep', pluginId: 'host' });
+
+      importer.register('plugin-a', {
+        plugin: { _routes: [] },
+        extensionRegistrations: [
+          {
+            extensionPointId: 'existing/ep',
+            registration: { id: 'contrib-ok', label: 'OK', value: 'v', meta: undefined },
+          },
+          {
+            extensionPointId: 'missing/ep',
+            registration: { id: 'contrib-pending', label: 'Pend', value: 'v', meta: undefined },
+          },
+        ],
+      });
+
+      await service.load('plugin-a');
+
+      expect(service.getPluginState('plugin-a')?.phase).toBe('ready');
+      const store = extensions.getExtensionPoint('existing/ep');
+      expect(store?.list()?.some((r: any) => r.id === 'plugin-a/contrib-ok')).toBe(true);
+      expect(service.getPendingContributions().get('missing/ep')).toHaveLength(1);
+    });
+  });
+
+  describe('replay from pending when EP appears', () => {
+    it('replays pending contributions when a plugin registers the target EP', async () => {
+      const { deps, importer, extensions } = createTestDeps();
+      const service = new PluginService(deps);
+
+      importer.register('plugin-a', {
+        plugin: { _routes: [] },
+        extensionRegistrations: [
+          {
+            extensionPointId: 'plugin-b/ep',
+            registration: { id: 'from-a', label: 'FromA', value: 'v', meta: undefined },
+          },
+        ],
+      });
+
+      await service.load('plugin-a');
+      expect(service.getPendingContributions().has('plugin-b/ep')).toBe(true);
+
+      importer.register('plugin-b', {
+        plugin: {
+          _routes: [],
+          _extensions: [{ id: 'plugin-b/ep', pluginId: 'plugin-b' }],
+        },
+        extensionRegistrations: [],
+      });
+
+      await service.load('plugin-b');
+
+      expect(service.getPendingContributions().has('plugin-b/ep')).toBe(false);
+      const store = extensions.getExtensionPoint('plugin-b/ep');
+      expect(store?.list()?.some((r: any) => r.id === 'plugin-a/from-a')).toBe(true);
+    });
+  });
+
+  describe('unload removes pending contributions', () => {
+    it('removes pending contributions when plugin is unloaded', async () => {
+      const { deps, importer } = createTestDeps();
+      const service = new PluginService(deps);
+
+      importer.register('plugin-a', {
+        plugin: { _routes: [] },
+        extensionRegistrations: [
+          {
+            extensionPointId: 'missing/ep',
+            registration: { id: 'contrib-1', label: 'C', value: 'v', meta: undefined },
+          },
+        ],
+      });
+
+      await service.load('plugin-a');
+      expect(service.getPendingContributions().has('missing/ep')).toBe(true);
+
+      await service.unload('plugin-a');
+      expect(service.getPendingContributions().has('missing/ep')).toBe(false);
+    });
+  });
+
+  describe('loadAll with soft resolution', () => {
+    it('holds contributions for EPs not registered by any plugin in the batch', async () => {
+      const { deps, importer } = createTestDeps();
+      const service = new PluginService(deps);
+
+      importer.register('plugin-a', {
+        plugin: { _routes: [] },
+        extensionRegistrations: [
+          {
+            extensionPointId: 'external/ep',
+            registration: { id: 'from-a', label: 'A', value: 'v', meta: undefined },
+          },
+        ],
+      });
+      importer.register('plugin-b', {
+        plugin: { _routes: [] },
+        extensionRegistrations: [],
+      });
+
+      await service.loadAll([
+        { id: 'plugin-a', dev: false },
+        { id: 'plugin-b', dev: false },
+      ]);
+
+      expect(service.getPluginState('plugin-a')?.phase).toBe('ready');
+      expect(service.getPluginState('plugin-b')?.phase).toBe('ready');
+      expect(service.getPendingContributions().has('external/ep')).toBe(true);
+    });
+
+    it('resolves cross-plugin contributions within a loadAll batch', async () => {
+      const { deps, importer, extensions } = createTestDeps();
+      const service = new PluginService(deps);
+
+      importer.register('plugin-a', {
+        plugin: { _routes: [] },
+        extensionRegistrations: [
+          {
+            extensionPointId: 'plugin-b/ep',
+            registration: { id: 'from-a', label: 'A', value: 'v', meta: undefined },
+          },
+        ],
+      });
+      importer.register('plugin-b', {
+        plugin: {
+          _routes: [],
+          _extensions: [{ id: 'plugin-b/ep', pluginId: 'plugin-b' }],
+        },
+        extensionRegistrations: [],
+      });
+
+      await service.loadAll([
+        { id: 'plugin-a', dev: false },
+        { id: 'plugin-b', dev: false },
+      ]);
+
+      expect(service.getPluginState('plugin-a')?.phase).toBe('ready');
+      expect(service.getPluginState('plugin-b')?.phase).toBe('ready');
+      const store = extensions.getExtensionPoint('plugin-b/ep');
+      expect(store?.list()?.some((r: any) => r.id === 'plugin-a/from-a')).toBe(true);
+    });
+  });
+
+  describe('debug snapshot includes pending', () => {
+    it('includes pending contributions in debug snapshot', async () => {
+      const { deps, importer } = createTestDeps();
+      const service = new PluginService(deps);
+
+      importer.register('plugin-a', {
+        plugin: { _routes: [] },
+        extensionRegistrations: [
+          {
+            extensionPointId: 'missing/ep',
+            registration: { id: 'contrib-1', label: 'C', value: 'v', meta: undefined },
+          },
+        ],
+      });
+
+      await service.load('plugin-a');
+      const snap = service.getDebugSnapshot();
+      expect(snap.pendingContributions['missing/ep']).toBeDefined();
+      expect(snap.pendingContributions['missing/ep']).toHaveLength(1);
+    });
+  });
+
+  describe('reset clears pending map', () => {
+    it('clears pending contributions on reset', async () => {
+      const { deps, importer } = createTestDeps();
+      const service = new PluginService(deps);
+
+      importer.register('plugin-a', {
+        plugin: { _routes: [] },
+        extensionRegistrations: [
+          {
+            extensionPointId: 'missing/ep',
+            registration: { id: 'contrib-1', label: 'C', value: 'v', meta: undefined },
+          },
+        ],
+      });
+
+      await service.load('plugin-a');
+      expect(service.getPendingContributions().size).toBeGreaterThan(0);
+
+      service.reset();
+      expect(service.getPendingContributions().size).toBe(0);
+    });
+  });
+});

--- a/ui/features/plugins/core/types.ts
+++ b/ui/features/plugins/core/types.ts
@@ -83,6 +83,7 @@ export interface PluginState {
   readonly pluginWindow: any | null; // PluginWindow at runtime
   readonly validationErrors: string[];
   readonly moduleHash: string | null;
+  readonly declaredDependencies?: DeclaredDependencies;
 }
 
 // ─── Validated Exports ───────────────────────────────────────────────
@@ -131,6 +132,7 @@ export interface PreparedPluginLoad {
   readonly isDev: boolean;
   readonly devPort: number | null;
   readonly moduleHash: string | null;
+  readonly declaredDependencies?: DeclaredDependencies;
 }
 
 // ─── Plugin Service Snapshot ─────────────────────────────────────────
@@ -149,6 +151,57 @@ export interface PluginDebugContributionRecord {
   readonly extensionPointId: string;
   readonly source: NormalizedContribution['source'];
   readonly resourceKey?: string;
+  readonly status: 'applied' | 'pending' | 'quarantined';
+  readonly crashCount: number;
+}
+
+// ─── Declared Dependencies (F1) ─────────────────────────────────────
+
+export interface DeclaredDependencies {
+  readonly plugins: readonly string[];
+  readonly extensionPoints: readonly string[];
+}
+
+// ─── Crash Data (F3) ────────────────────────────────────────────────
+
+export interface CrashRecord {
+  readonly contributionId: string;
+  readonly pluginId: string;
+  readonly extensionPointId: string;
+  readonly boundary: string;
+  readonly resourceKey?: string;
+  readonly errorMessage: string;
+  readonly stack?: string;
+  readonly componentStack?: string;
+  readonly timestamp: number;
+}
+
+export interface CrashDataStrategy {
+  recordCrash(record: CrashRecord): void;
+  clearForContribution(contributionId: string): void;
+  clearForPlugin(pluginId: string): void;
+  clearAll(): void;
+  getCrashCount(contributionId: string): number;
+  getCrashHistory(contributionId: string): readonly CrashRecord[];
+  getAllCrashHistory(): ReadonlyMap<string, readonly CrashRecord[]>;
+  subscribe(listener: () => void): () => void;
+}
+
+// ─── Quarantine (F2) ────────────────────────────────────────────────
+
+export interface QuarantineInfo {
+  readonly contributionId: string;
+  readonly pluginId: string;
+  readonly extensionPointId: string;
+  readonly crashCount: number;
+  readonly quarantinedAt: number;
+}
+
+// ─── Dependency Graph (F1) ──────────────────────────────────────────
+
+export interface DependencyGraph {
+  readonly nodes: readonly string[];
+  readonly edges: readonly [from: string, to: string][];
 }
 
 export interface PluginServiceDebugPluginState extends PluginState {
@@ -156,6 +209,7 @@ export interface PluginServiceDebugPluginState extends PluginState {
   readonly contributedExtensionPoints: string[];
   readonly contributions: PluginDebugContributionRecord[];
   readonly definedExtensionPoints: string[];
+  readonly dependencyWarnings: string[];
 }
 
 export interface PluginServiceDebugSnapshot {
@@ -164,6 +218,9 @@ export interface PluginServiceDebugSnapshot {
   readonly ready: boolean;
   readonly routeVersion: number;
   readonly eventListenersActive: boolean;
+  readonly pendingContributions: Record<string, { pluginId: string; contributionId: string; extensionPointId: string }[]>;
+  readonly quarantinedContributions: QuarantineInfo[];
+  readonly recentCrashes: CrashRecord[];
 }
 
 // ─── Plugin Import/Load Options ──────────────────────────────────────
@@ -196,6 +253,8 @@ export interface PluginServiceConfig {
   readonly retryBaseDelayMs: number;
   readonly retryMaxDelayMs: number;
   readonly maxConcurrentLoads: number;
+  readonly quarantineCrashThreshold: number;
+  readonly maxCrashRecordsPerContribution: number;
 }
 
 export const DEFAULT_CONFIG: Readonly<PluginServiceConfig> = {
@@ -204,6 +263,8 @@ export const DEFAULT_CONFIG: Readonly<PluginServiceConfig> = {
   retryBaseDelayMs: 1_000,
   retryMaxDelayMs: 30_000,
   maxConcurrentLoads: 5,
+  quarantineCrashThreshold: 3,
+  maxCrashRecordsPerContribution: 10,
 };
 
 // ─── Plugin Service Dependencies ─────────────────────────────────────
@@ -233,6 +294,7 @@ export interface PluginServiceDeps {
   removeContributions(pluginId: string): void;
   ensureDevSharedDeps(): Promise<void>;
   validateExports(exports: unknown): ValidatedExports;
+  crashData: CrashDataStrategy;
 
   log: {
     debug(message: string, data?: Record<string, unknown>): void;

--- a/ui/features/plugins/core/validation.test.ts
+++ b/ui/features/plugins/core/validation.test.ts
@@ -344,6 +344,77 @@ describe('validatePluginExports', () => {
       expect(() => validatePluginExports({ plugin: p })).toThrow(/string.*id/);
     });
   });
+
+  // ── 1.7 Dependencies Field Validation ─────────────────────────────
+
+  describe('validatePluginExports — dependencies field', () => {
+    it('accepts exports without dependencies (backward compatible)', () => {
+      const result = validatePluginExports({ plugin: pw() });
+      expect(result.plugin).toBeDefined();
+    });
+
+    it('accepts valid dependencies object', () => {
+      const result = validatePluginExports({
+        plugin: pw(),
+        dependencies: { plugins: ['plugin-a', 'plugin-b'], extensionPoints: ['ep/1'] },
+      });
+      expect(result.plugin).toBeDefined();
+    });
+
+    it('accepts dependencies with only plugins', () => {
+      const result = validatePluginExports({
+        plugin: pw(),
+        dependencies: { plugins: ['plugin-a'] },
+      });
+      expect(result.plugin).toBeDefined();
+    });
+
+    it('accepts dependencies with only extensionPoints', () => {
+      const result = validatePluginExports({
+        plugin: pw(),
+        dependencies: { extensionPoints: ['ep/1'] },
+      });
+      expect(result.plugin).toBeDefined();
+    });
+
+    it('accepts empty dependencies object', () => {
+      const result = validatePluginExports({
+        plugin: pw(),
+        dependencies: {},
+      });
+      expect(result.plugin).toBeDefined();
+    });
+
+    it('rejects non-object dependencies', () => {
+      expect(() =>
+        validatePluginExports({ plugin: pw(), dependencies: 'bad' }),
+      ).toThrow(/dependencies.*object/i);
+    });
+
+    it('rejects dependencies.plugins that is not an array', () => {
+      expect(() =>
+        validatePluginExports({ plugin: pw(), dependencies: { plugins: 'not-array' } }),
+      ).toThrow(/plugins.*array/i);
+    });
+
+    it('rejects dependencies.plugins with non-string items', () => {
+      expect(() =>
+        validatePluginExports({ plugin: pw(), dependencies: { plugins: [123] } }),
+      ).toThrow(/plugins.*string/i);
+    });
+
+    it('rejects dependencies.extensionPoints that is not an array', () => {
+      expect(() =>
+        validatePluginExports({ plugin: pw(), dependencies: { extensionPoints: {} } }),
+      ).toThrow(/extensionPoints.*array/i);
+    });
+
+    it('rejects dependencies.extensionPoints with non-string items', () => {
+      expect(() =>
+        validatePluginExports({ plugin: pw(), dependencies: { extensionPoints: [null] } }),
+      ).toThrow(/extensionPoints.*string/i);
+    });
+  });
 });
 
 // ─── validateResourceKeyFormat ───────────────────────────────────────

--- a/ui/features/plugins/core/validation.ts
+++ b/ui/features/plugins/core/validation.ts
@@ -206,6 +206,51 @@ export function validatePluginExports(exports: unknown): ValidatedExports {
     }
   }
 
+  // --- dependencies (optional, advisory) ---
+  if ('dependencies' in exp && exp.dependencies !== undefined && exp.dependencies !== null) {
+    if (typeof exp.dependencies !== 'object' || Array.isArray(exp.dependencies)) {
+      throw new PluginValidationError(
+        "'dependencies' must be an object",
+        { errors: ["'dependencies' must be an object"] },
+      );
+    }
+    const deps = exp.dependencies as Record<string, unknown>;
+
+    if ('plugins' in deps && deps.plugins !== undefined) {
+      if (!Array.isArray(deps.plugins)) {
+        throw new PluginValidationError(
+          "'dependencies.plugins' must be an array",
+          { errors: ["'dependencies.plugins' must be an array"] },
+        );
+      }
+      for (const item of deps.plugins) {
+        if (typeof item !== 'string') {
+          throw new PluginValidationError(
+            "'dependencies.plugins' must contain only strings",
+            { errors: ["'dependencies.plugins' must contain only strings"] },
+          );
+        }
+      }
+    }
+
+    if ('extensionPoints' in deps && deps.extensionPoints !== undefined) {
+      if (!Array.isArray(deps.extensionPoints)) {
+        throw new PluginValidationError(
+          "'dependencies.extensionPoints' must be an array",
+          { errors: ["'dependencies.extensionPoints' must be an array"] },
+        );
+      }
+      for (const item of deps.extensionPoints) {
+        if (typeof item !== 'string') {
+          throw new PluginValidationError(
+            "'dependencies.extensionPoints' must contain only strings",
+            { errors: ["'dependencies.extensionPoints' must contain only strings"] },
+          );
+        }
+      }
+    }
+  }
+
   return {
     plugin: plugin as ValidatedExports['plugin'],
     extensionRegistrations: extensionRegistrations as ValidatedExports['extensionRegistrations'],

--- a/ui/features/plugins/index.ts
+++ b/ui/features/plugins/index.ts
@@ -4,6 +4,7 @@ export { PluginServiceProvider } from './react/PluginServiceProvider';
 export { usePluginService } from './react/usePluginService';
 export { usePluginRoutes } from './react/usePluginRoutes';
 export { ExtensionPointRenderer } from './components/ExtensionPointRenderer';
+export { QuarantinedContributionFallback } from './components/QuarantinedContributionFallback';
 export { PluginSurfaceBoundary } from './components/PluginSurfaceBoundary';
 export {
   logPluginBoundaryError,
@@ -18,6 +19,11 @@ export type {
   PluginServiceConfig,
   PluginServiceDebugSnapshot,
   ResourceExtensionRenderContext,
+  DeclaredDependencies,
+  CrashRecord,
+  CrashDataStrategy,
+  QuarantineInfo,
+  DependencyGraph,
 } from './core/types';
 
 export type {
@@ -29,3 +35,6 @@ export type {
   DefaultExtensionFallbackProps,
   DefaultPluginFallbackProps,
 } from './components/PluginSurfaceBoundary';
+export type {
+  QuarantinedContributionFallbackProps,
+} from './components/QuarantinedContributionFallback';

--- a/ui/features/plugins/react/PluginServiceProvider.tsx
+++ b/ui/features/plugins/react/PluginServiceProvider.tsx
@@ -68,6 +68,17 @@ export function PluginServiceProvider({ children }: PluginServiceProviderProps) 
       });
   }, [isLoading, installedPlugins, service]);
 
+  // Listen for quarantine activations
+  useEffect(() => {
+    const cleanup = service.onQuarantineActivated((info) => {
+      // TODO: Wire to notification/toast system when available
+      console.warn(
+        `[PluginService] Contribution quarantined: ${info.contributionId} (plugin: ${info.pluginId}, crashes: ${info.crashCount})`,
+      );
+    });
+    return cleanup;
+  }, [service]);
+
   // Dev mode: expose debug surface
   useEffect(() => {
     if (import.meta.env.DEV) {
@@ -75,6 +86,10 @@ export function PluginServiceProvider({ children }: PluginServiceProviderProps) 
         getDebugSnapshot: service.getDebugSnapshot.bind(service),
         forceReset: service.forceReset.bind(service),
         retry: service.retry.bind(service),
+        unquarantine: service.unquarantine.bind(service),
+        listQuarantined: service.listQuarantined.bind(service),
+        getCrashCount: service.getCrashCount.bind(service),
+        getDependencyGraph: service.getDependencyGraph.bind(service),
       };
       return () => {
         delete (window as any).__PLUGIN_SERVICE__;

--- a/ui/features/plugins/react/usePluginService.ts
+++ b/ui/features/plugins/react/usePluginService.ts
@@ -10,6 +10,11 @@ export interface UsePluginServiceResult extends PluginServiceSnapshot {
   readonly retry: PluginService['retry'];
   readonly forceReset: PluginService['forceReset'];
   readonly getDebugSnapshot: PluginService['getDebugSnapshot'];
+  readonly isQuarantined: PluginService['isQuarantined'];
+  readonly unquarantine: PluginService['unquarantine'];
+  readonly listQuarantined: PluginService['listQuarantined'];
+  readonly getDependencyGraph: PluginService['getDependencyGraph'];
+  readonly getDependencyWarnings: PluginService['getDependencyWarnings'];
 }
 
 /**
@@ -35,6 +40,11 @@ export function usePluginService(): UsePluginServiceResult {
       retry: service.retry.bind(service),
       forceReset: service.forceReset.bind(service),
       getDebugSnapshot: service.getDebugSnapshot.bind(service),
+      isQuarantined: service.isQuarantined.bind(service),
+      unquarantine: service.unquarantine.bind(service),
+      listQuarantined: service.listQuarantined.bind(service),
+      getDependencyGraph: service.getDependencyGraph.bind(service),
+      getDependencyWarnings: service.getDependencyWarnings.bind(service),
     }),
     [service],
   );

--- a/ui/features/plugins/testing/helpers.ts
+++ b/ui/features/plugins/testing/helpers.ts
@@ -1,6 +1,6 @@
 import { ExtensionPointRegistry } from '@omniviewdev/runtime';
 import { validatePluginExports } from '../core/validation';
-import { MissingExtensionPointError } from '../core/errors';
+import { MissingExtensionPointError, DuplicateContributionError } from '../core/errors';
 import { InMemoryCrashDataStrategy } from '../core/CrashDataService';
 import type {
   PluginServiceDeps,
@@ -188,7 +188,19 @@ export function createTestDeps(opts?: { maxCrashRecordsPerContribution?: number 
           },
         );
       }
-      store.register(contribution);
+      try {
+        store.register(contribution);
+      } catch (err) {
+        if (err instanceof Error && err.message.includes('already exists')) {
+          throw new DuplicateContributionError(err.message, {
+            pluginId: contribution.plugin,
+            extensionPointId,
+            contributionId: contribution.id,
+            cause: err,
+          });
+        }
+        throw err;
+      }
     },
 
     removeContributions: (pluginId) => {

--- a/ui/features/plugins/testing/helpers.ts
+++ b/ui/features/plugins/testing/helpers.ts
@@ -1,6 +1,7 @@
 import { ExtensionPointRegistry } from '@omniviewdev/runtime';
 import { validatePluginExports } from '../core/validation';
 import { MissingExtensionPointError } from '../core/errors';
+import { InMemoryCrashDataStrategy } from '../core/CrashDataService';
 import type {
   PluginServiceDeps,
   PluginImportOpts,
@@ -126,6 +127,7 @@ export interface TestDeps {
   eventBus: InMemoryEventBus;
   extensions: ExtensionPointRegistry;
   log: LogCapture;
+  crashData: InMemoryCrashDataStrategy;
 }
 
 /**
@@ -150,8 +152,10 @@ export function createTestDeps(): TestDeps {
   const eventBus = new InMemoryEventBus();
   const extensions = new ExtensionPointRegistry();
   const log = new LogCapture();
+  const crashData = new InMemoryCrashDataStrategy({ maxRecordsPerContribution: 10 });
 
   const deps: PluginServiceDeps = {
+    crashData,
     importPlugin: importer.importPlugin,
 
     clearPlugin: async () => {
@@ -199,7 +203,7 @@ export function createTestDeps(): TestDeps {
     log: log.logger,
   };
 
-  return { deps, importer, eventBus, extensions, log };
+  return { deps, importer, eventBus, extensions, log, crashData };
 }
 
 // ─── Deferred Promise ───────────────────────────────────────────────

--- a/ui/features/plugins/testing/helpers.ts
+++ b/ui/features/plugins/testing/helpers.ts
@@ -147,12 +147,12 @@ export interface TestDeps {
  * - Cache invalidation works
  * - Subscriptions fire
  */
-export function createTestDeps(): TestDeps {
+export function createTestDeps(opts?: { maxCrashRecordsPerContribution?: number }): TestDeps {
   const importer = new InMemoryModuleImporter();
   const eventBus = new InMemoryEventBus();
   const extensions = new ExtensionPointRegistry();
   const log = new LogCapture();
-  const crashData = new InMemoryCrashDataStrategy({ maxRecordsPerContribution: 10 });
+  const crashData = new InMemoryCrashDataStrategy({ maxRecordsPerContribution: opts?.maxCrashRecordsPerContribution ?? 10 });
 
   const deps: PluginServiceDeps = {
     crashData,


### PR DESCRIPTION
## Summary

- **Soft contribution resolution**: Contributions targeting missing extension points are held in a pending map and automatically replayed when the target EP appears, replacing the previous fail-fast behavior that could break entire plugin loads due to cross-plugin timing.

- **Session-local crash quarantine**: `QuarantineManager` suppresses repeatedly crashing contributions at render time (configurable threshold, default 3). Dev mode shows an inline fallback with re-enable button; production silently hides quarantined contributions. Crash data is tracked via `CrashDataStrategy` with bounded ring-buffer storage.

- **Advisory dependency analysis**: `DependencyAnalyzer` tracks declared plugin and extension-point dependencies, detects cycles via Tarjan's SCC algorithm, and emits advisory warnings. Never blocks loading — purely informational for debugging and dev tools.

- **Foundation**: New types (`DeclaredDependencies`, `CrashRecord`, `QuarantineInfo`, `DependencyGraph`), validation for the `dependencies` export field, `extractDeclaredDependencies` normalization, and `InMemoryCrashDataStrategy` wired into both production and test dependency injection.

## Test plan

- [x] 438 tests passing across 17 test files (0 regressions)
- [x] Zero TypeScript errors (`tsc --noEmit`)
- [x] CrashDataService: 15 tests (record/evict/clear/subscribe)
- [x] QuarantineManager: 11 tests (threshold/event/unquarantine/clear)
- [x] DependencyAnalyzer: 15 tests (add/remove/Tarjan SCC/missing deps/graph)
- [x] Soft resolution: 8 integration tests (hold/replay/cross-plugin/debug snapshot)
- [x] Validation: 10 new tests for dependencies field
- [x] Normalization: 5 new tests for extractDeclaredDependencies
- [x] Updated 2 existing tests from fail-fast to soft resolution semantics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Crash tracking with in-memory crash store, automatic quarantining of unstable contributions, dev-mode quarantined contribution UI with re-enable action
  * Plugin dependency management: validation, cycle detection and dependency graph with warnings
  * Pending contributions queue for missing extension points; new debug hooks (crash counts, quarantines, dependency graph, pending contributions)

* **Bug Fixes**
  * Missing extension points no longer fail loads; contributions are queued and replayed when available

* **Tests**
  * Extensive tests for crash data, quarantine manager, dependency analyzer, soft-resolution and validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->