### PR TITLE
Fix resource table not filling available vertical space

### DIFF
--- a/ui/layouts/core/sidenav/Main/index.tsx
+++ b/ui/layouts/core/sidenav/Main/index.tsx
@@ -9,7 +9,7 @@ const Main: React.FC<BoxProps> = props => (
     component='main'
     className='Main'
     {...props}
-    sx={[{ width: '100%' }, ...(Array.isArray(props.sx) ? props.sx : [props.sx])]}
+    sx={[{ width: '100%', minHeight: 0 }, ...(Array.isArray(props.sx) ? props.sx : [props.sx])]}
   />
 );
 

--- a/ui/layouts/core/sidenav/Root/index.tsx
+++ b/ui/layouts/core/sidenav/Root/index.tsx
@@ -12,10 +12,9 @@ const Root: React.FC<BoxProps> = (props: BoxProps) => (
         bgcolor: 'background.default',
         display: 'flex',
         flexDirection: 'row',
-        flexGrow: 1,
+        flex: 1,
+        minHeight: 0,
         overflow: 'hidden',
-        // minHeight: '100%',
-        // maxHeight: '100%',
         // Display: 'grid',
         // gridTemplateColumns: {
         //   xs: '1fr',


### PR DESCRIPTION
## Summary
- Added `minHeight: 0` to `Layout.Root` and `Layout.Main` sidenav components to complete the flexbox constraint chain
- Changed `Layout.Root` from `flexGrow: 1` to `flex: 1` for consistency
- These two missing properties broke the flex height propagation, preventing the virtualized resource table from expanding to fill its container

## Verification
- `pnpm build` passes
- ESLint `pnpm lint` has a pre-existing config issue (points to nonexistent `src` dir) — not related to this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated sidebar navigation layout styling, including adjustments to flex properties and minimum height values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->