### PR TITLE
Fix log level parsing matching 'error' in non-error contexts

### DIFF
--- a/ui/providers/BottomDrawer/containers/LogViewer/utils/parseLogLine.ts
+++ b/ui/providers/BottomDrawer/containers/LogViewer/utils/parseLogLine.ts
@@ -23,7 +23,7 @@ const JSON_LEVEL_RE =
 const BRACKET_LEVEL_RE = /\[([A-Za-z]+)\]/g;
 
 // Match key=value level: level=ERROR, severity=warn, level = "error", severity : 'warn'
-const KV_LEVEL_RE = /\b(?:level|severity|lvl)\s*[=:]\s*["']?([a-zA-Z]+)["']?\b/i;
+const KV_LEVEL_RE = /\b(?:level|severity|lvl)\s*[=:]\s*["']?([a-zA-Z]+)\b["']?/i;
 
 // Match level keyword at/near line start (with optional leading timestamp):
 // "ERROR ...", "2024-01-01 ERROR ...", "2024-01-01T00:00:00Z ERROR ..."

--- a/ui/providers/BottomDrawer/containers/LogViewer/utils/parseLogLine.ts
+++ b/ui/providers/BottomDrawer/containers/LogViewer/utils/parseLogLine.ts
@@ -1,20 +1,64 @@
 import type { LogEntry, LogLevel, RawLogLine } from '../types';
 import { parseAnsi } from './parseAnsi';
 
-const LEVEL_PATTERNS: Array<{ level: LogLevel; pattern: RegExp }> = [
-  { level: 'error', pattern: /\b(ERROR|ERR|FATAL|PANIC|CRITICAL)\b/i },
-  { level: 'warn', pattern: /\b(WARN|WARNING)\b/i },
-  { level: 'info', pattern: /\b(INFO)\b/i },
-  { level: 'debug', pattern: /\b(DEBUG|DBG)\b/i },
-  { level: 'trace', pattern: /\b(TRACE|TRC)\b/i },
+const LEVEL_KEYWORDS: Array<{ level: LogLevel; words: string[] }> = [
+  { level: 'error', words: ['error', 'err', 'fatal', 'panic', 'critical'] },
+  { level: 'warn', words: ['warn', 'warning'] },
+  { level: 'info', words: ['info'] },
+  { level: 'debug', words: ['debug', 'dbg'] },
+  { level: 'trace', words: ['trace', 'trc'] },
 ];
 
+const LEVEL_WORD_SET = new Map<string, LogLevel>(
+  LEVEL_KEYWORDS.flatMap(({ level, words }) =>
+    words.map((w) => [w, level] as const),
+  ),
+);
+
+// Match level in JSON fields: "level":"error", "severity":"WARN", "lvl":"info"
+const JSON_LEVEL_RE =
+  /["'](?:level|severity|lvl)["']\s*[:=]\s*["']([a-zA-Z]+)["']/i;
+
+// Match bracketed level: [ERROR], [WARN], [info]
+const BRACKET_LEVEL_RE = /\[([A-Za-z]+)\]/g;
+
+// Match key=value level: level=ERROR, severity=warn
+const KV_LEVEL_RE = /\b(?:level|severity|lvl)[=:]([a-zA-Z]+)\b/i;
+
+// Match level keyword at/near line start (with optional leading timestamp):
+// "ERROR ...", "2024-01-01 ERROR ...", "2024-01-01T00:00:00Z ERROR ..."
+const START_LEVEL_RE = /^[\d\-T:.Z+/ ]{0,35}\b([A-Za-z]+)\b/;
+
 function detectLevel(content: string): LogLevel | undefined {
-  for (const { level, pattern } of LEVEL_PATTERNS) {
-    if (pattern.test(content)) {
-      return level;
-    }
+  // 1. JSON field match
+  const jsonMatch = JSON_LEVEL_RE.exec(content);
+  if (jsonMatch) {
+    const found = LEVEL_WORD_SET.get(jsonMatch[1].toLowerCase());
+    if (found) return found;
   }
+
+  // 2. Key=value match
+  const kvMatch = KV_LEVEL_RE.exec(content);
+  if (kvMatch) {
+    const found = LEVEL_WORD_SET.get(kvMatch[1].toLowerCase());
+    if (found) return found;
+  }
+
+  // 3. Bracketed match — scan all brackets, return first recognized level
+  BRACKET_LEVEL_RE.lastIndex = 0;
+  let bracketMatch: RegExpExecArray | null;
+  while ((bracketMatch = BRACKET_LEVEL_RE.exec(content)) !== null) {
+    const found = LEVEL_WORD_SET.get(bracketMatch[1].toLowerCase());
+    if (found) return found;
+  }
+
+  // 4. Level keyword near line start (after optional timestamp)
+  const startMatch = START_LEVEL_RE.exec(content);
+  if (startMatch) {
+    const found = LEVEL_WORD_SET.get(startMatch[1].toLowerCase());
+    if (found) return found;
+  }
+
   return undefined;
 }
 

--- a/ui/providers/BottomDrawer/containers/LogViewer/utils/parseLogLine.ts
+++ b/ui/providers/BottomDrawer/containers/LogViewer/utils/parseLogLine.ts
@@ -22,8 +22,8 @@ const JSON_LEVEL_RE =
 // Match bracketed level: [ERROR], [WARN], [info]
 const BRACKET_LEVEL_RE = /\[([A-Za-z]+)\]/g;
 
-// Match key=value level: level=ERROR, severity=warn
-const KV_LEVEL_RE = /\b(?:level|severity|lvl)[=:]([a-zA-Z]+)\b/i;
+// Match key=value level: level=ERROR, severity=warn, level = "error", severity : 'warn'
+const KV_LEVEL_RE = /\b(?:level|severity|lvl)\s*[=:]\s*["']?([a-zA-Z]+)["']?\b/i;
 
 // Match level keyword at/near line start (with optional leading timestamp):
 // "ERROR ...", "2024-01-01 ERROR ...", "2024-01-01T00:00:00Z ERROR ..."


### PR DESCRIPTION
## Summary
- Replaced broad word-boundary regex matching with structured position detection
- Log levels now only detected in JSON fields (`level`/`severity`/`lvl`), key=value pairs, bracketed markers (`[ERROR]`), or near line start (after optional timestamp)
- Fixes false positives where words like "error" in message body (e.g. "connection error count") triggered error-level highlighting

## Ticket
Bug: Log level parsing matches 'error' in non-error contexts

## Verification
- `pnpm build` — passes
- `tsc --noEmit` — passes
- `pnpm lint` — pre-existing config issue (targets `src/` but code is in `ui/`), not related to this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved log level detection in the LogViewer to handle multiple log format variations, including JSON fields, key-value pairs, bracketed tags, and logs with timestamps.
  * Enhanced keyword recognition to properly identify various log level synonyms across different logging formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->