### PR TITLE
feat: default to hiding timestamps and source badges in log viewer

### DIFF
--- a/ui/providers/BottomDrawer/containers/LogViewer/index.tsx
+++ b/ui/providers/BottomDrawer/containers/LogViewer/index.tsx
@@ -39,8 +39,8 @@ interface Props {
 
 const LogViewerContainer: React.FC<Props> = ({ sessionId, source, toolbarPrefix, toolbarActions }) => {
   const parentRef = useRef<HTMLDivElement>(null);
-  const [showTimestamps, setShowTimestamps] = useState(true);
-  const [showSources, setShowSources] = useState(true);
+  const [showTimestamps, setShowTimestamps] = useState(false);
+  const [showSources, setShowSources] = useState(false);
   const [showLineNumbers, setShowLineNumbers] = useState(false);
   const [wrap, setWrap] = useState(false);
   const [colorize, setColorize] = useState(true);


### PR DESCRIPTION
## Summary
- Default `showTimestamps` and `showSources` to `false` in the LogViewer component
- Reduces visual noise in log output by hiding timestamp and source badge columns by default
- Users can still toggle them on via the toolbar controls

## Ticket
Feature: Default to hiding time and workload chip in resource tables

## Verification
- `pnpm build` succeeds
- Lint script has a pre-existing misconfiguration (targets `src/` instead of `ui/`), but tsc type-checking passes during build