### PR TITLE
fix: recovery path after failed plugin reconnection

### DIFF
--- a/backend/pkg/plugin/health.go
+++ b/backend/pkg/plugin/health.go
@@ -123,6 +123,18 @@ func (hc *HealthChecker) CancelRecovery(pluginID string) {
 	delete(hc.crashBudgets, pluginID)
 }
 
+// ResetBudget clears the crash budget and recovery state for a plugin.
+// This should be called when the user manually triggers a reload so that
+// the plugin gets fresh retry attempts instead of being immediately
+// rejected by an exhausted budget from a prior crash cycle.
+func (hc *HealthChecker) ResetBudget(pluginID string) {
+	hc.mu.Lock()
+	defer hc.mu.Unlock()
+
+	delete(hc.crashBudgets, pluginID)
+	delete(hc.recoveryStates, pluginID)
+}
+
 // IsInCrashCycle returns true if the plugin has already crashed at least once
 // within the current budget window. Used by HandlePluginCrash to suppress
 // repeated "plugin/crash" notifications during crash-recover-crash loops.

--- a/backend/pkg/plugin/loader.go
+++ b/backend/pkg/plugin/loader.go
@@ -281,6 +281,11 @@ func (pm *pluginManager) ReloadPlugin(id string) (sdktypes.PluginInfo, error) {
 		},
 	}
 
+	// Clear any exhausted crash budget so a manual reload gets fresh retries.
+	if pm.healthChecker != nil {
+		pm.healthChecker.ResetBudget(id)
+	}
+
 	if err := pm.unloadPluginLocked(id); err != nil {
 		return sdktypes.PluginInfo{}, apperror.Wrap(err, apperror.TypePluginLoadFailed, 500,
 			"Failed to unload plugin during reload").WithInstance(id)

--- a/backend/pkg/plugin/loader.go
+++ b/backend/pkg/plugin/loader.go
@@ -281,16 +281,22 @@ func (pm *pluginManager) ReloadPlugin(id string) (sdktypes.PluginInfo, error) {
 		},
 	}
 
-	// Clear any exhausted crash budget so a manual reload gets fresh retries.
-	if pm.healthChecker != nil {
-		pm.healthChecker.ResetBudget(id)
-	}
-
 	if err := pm.unloadPluginLocked(id); err != nil {
 		return sdktypes.PluginInfo{}, apperror.Wrap(err, apperror.TypePluginLoadFailed, 500,
 			"Failed to unload plugin during reload").WithInstance(id)
 	}
 	return pm.loadPluginLocked(id, opts)
+}
+
+// RetryFailedPlugin resets the crash budget and reloads the plugin.
+// Use this for user-initiated retries (e.g. the UI "Retry Plugin" button)
+// so the plugin gets fresh recovery attempts. Do NOT use for automated
+// crash recovery — use ReloadPlugin instead.
+func (pm *pluginManager) RetryFailedPlugin(id string) (sdktypes.PluginInfo, error) {
+	if pm.healthChecker != nil {
+		pm.healthChecker.CancelRecovery(id)
+	}
+	return pm.ReloadPlugin(id)
 }
 
 // UnloadPlugin unloads a plugin, stopping it if running.

--- a/backend/pkg/plugin/manager.go
+++ b/backend/pkg/plugin/manager.go
@@ -71,6 +71,7 @@ type Manager interface {
 
 	LoadPlugin(id string, opts *LoadPluginOptions) (sdktypes.PluginInfo, error)
 	ReloadPlugin(id string) (sdktypes.PluginInfo, error)
+	RetryFailedPlugin(id string) (sdktypes.PluginInfo, error)
 	UninstallPlugin(id string) (sdktypes.PluginInfo, error)
 
 	GetPlugin(id string) (sdktypes.PluginInfo, error)

--- a/packages/omniviewdev-runtime/src/hooks/connection/useConnectionStatus.ts
+++ b/packages/omniviewdev-runtime/src/hooks/connection/useConnectionStatus.ts
@@ -6,7 +6,7 @@ import {
   StopConnection,
   StartConnectionWatch,
 } from '../../wailsjs/go/resource/Client';
-import { ReloadPlugin } from '../../wailsjs/go/plugin/pluginManager';
+import { RetryFailedPlugin } from '../../wailsjs/go/plugin/pluginManager';
 import type { types } from '../../wailsjs/go/models';
 import { WatchState } from '../../types/watch';
 import type { WatchStateEvent } from '../../types/watch';
@@ -87,20 +87,22 @@ export function useConnectionStatus(): ConnectionStatusSummary {
   // Listen for plugin crash recovery events
   useEffect(() => {
     const cancelCrash = EventsOn('plugin/crash_recovery_failed', (data: { pluginID?: string; error?: string }) => {
-      if (!data?.pluginID) return;
+      const pluginID = data?.pluginID;
+      if (!pluginID) return;
       setFailedPlugins((prev) => {
         const next = new Map(prev);
-        next.set(data.pluginID!, data.error ?? 'Crash recovery failed');
+        next.set(pluginID, data.error ?? 'Crash recovery failed');
         return next;
       });
     });
 
     const cancelRecovered = EventsOn('plugin/recovered', (data: { pluginID?: string }) => {
-      if (!data?.pluginID) return;
+      const pluginID = data?.pluginID;
+      if (!pluginID) return;
       setFailedPlugins((prev) => {
-        if (!prev.has(data.pluginID!)) return prev;
+        if (!prev.has(pluginID)) return prev;
         const next = new Map(prev);
-        next.delete(data.pluginID!);
+        next.delete(pluginID);
         return next;
       });
     });
@@ -235,6 +237,7 @@ export function useConnectionStatus(): ConnectionStatusSummary {
   }, []);
 
   const retryPlugin = useCallback(async (pluginID: string) => {
+    const previousError = failedPlugins.get(pluginID);
     // Clear the failed state optimistically before reload
     setFailedPlugins((prev) => {
       if (!prev.has(pluginID)) return prev;
@@ -242,8 +245,18 @@ export function useConnectionStatus(): ConnectionStatusSummary {
       next.delete(pluginID);
       return next;
     });
-    await ReloadPlugin(pluginID);
-  }, []);
+    try {
+      await RetryFailedPlugin(pluginID);
+    } catch (err) {
+      // Restore failed state if reload fails immediately
+      setFailedPlugins((prev) => {
+        const next = new Map(prev);
+        next.set(pluginID, previousError ?? 'Reload failed');
+        return next;
+      });
+      throw err;
+    }
+  }, [failedPlugins]);
 
   // Build entries from started connections
   const entries: ConnectionStatusEntry[] = [];

--- a/packages/omniviewdev-runtime/src/hooks/connection/useConnectionStatus.ts
+++ b/packages/omniviewdev-runtime/src/hooks/connection/useConnectionStatus.ts
@@ -6,6 +6,7 @@ import {
   StopConnection,
   StartConnectionWatch,
 } from '../../wailsjs/go/resource/Client';
+import { ReloadPlugin } from '../../wailsjs/go/plugin/pluginManager';
 import type { types } from '../../wailsjs/go/models';
 import { WatchState } from '../../types/watch';
 import type { WatchStateEvent } from '../../types/watch';
@@ -44,6 +45,10 @@ export interface ConnectionStatusEntry {
   sync?: ActiveSync;
   isSyncing: boolean;
   hasErrors: boolean;
+  /** True when the plugin's crash recovery has been exhausted */
+  pluginFailed: boolean;
+  /** Error message from the crash recovery failure */
+  pluginError?: string;
 }
 
 export interface ConnectionStatusSummary {
@@ -52,12 +57,15 @@ export interface ConnectionStatusSummary {
   connectedCount: number;
   syncingCount: number;
   errorCount: number;
+  failedCount: number;
   hasSyncing: boolean;
   aggregateProgress: number;
   /** Disconnect a connection by plugin/connection ID */
   disconnect: (pluginID: string, connectionID: string) => Promise<void>;
   /** Retry watch sync for a connection */
   retryWatch: (pluginID: string, connectionID: string) => Promise<void>;
+  /** Retry a failed plugin (reload it after crash recovery exhaustion) */
+  retryPlugin: (pluginID: string) => Promise<void>;
 }
 
 /**
@@ -72,6 +80,36 @@ export function useConnectionStatus(): ConnectionStatusSummary {
   // Sync state per connection
   const [syncs, setSyncs] = useState<Map<string, ActiveSync>>(new Map());
   const trackersRef = useRef<Map<string, ResourceTracker>>(new Map());
+
+  // Track plugins whose crash recovery has been exhausted
+  const [failedPlugins, setFailedPlugins] = useState<Map<string, string>>(new Map());
+
+  // Listen for plugin crash recovery events
+  useEffect(() => {
+    const cancelCrash = EventsOn('plugin/crash_recovery_failed', (data: { pluginID?: string; error?: string }) => {
+      if (!data?.pluginID) return;
+      setFailedPlugins((prev) => {
+        const next = new Map(prev);
+        next.set(data.pluginID!, data.error ?? 'Crash recovery failed');
+        return next;
+      });
+    });
+
+    const cancelRecovered = EventsOn('plugin/recovered', (data: { pluginID?: string }) => {
+      if (!data?.pluginID) return;
+      setFailedPlugins((prev) => {
+        if (!prev.has(data.pluginID!)) return prev;
+        const next = new Map(prev);
+        next.delete(data.pluginID!);
+        return next;
+      });
+    });
+
+    return () => {
+      cancelCrash();
+      cancelRecovered();
+    };
+  }, []);
 
   // Hydrate full connection + watch state on mount
   useEffect(() => {
@@ -196,6 +234,17 @@ export function useConnectionStatus(): ConnectionStatusSummary {
     await StartConnectionWatch(pluginID, connectionID);
   }, []);
 
+  const retryPlugin = useCallback(async (pluginID: string) => {
+    // Clear the failed state optimistically before reload
+    setFailedPlugins((prev) => {
+      if (!prev.has(pluginID)) return prev;
+      const next = new Map(prev);
+      next.delete(pluginID);
+      return next;
+    });
+    await ReloadPlugin(pluginID);
+  }, []);
+
   // Build entries from started connections
   const entries: ConnectionStatusEntry[] = [];
   for (const key of startedKeys) {
@@ -205,6 +254,7 @@ export function useConnectionStatus(): ConnectionStatusSummary {
     const sync = syncs.get(key);
     const syncing = sync != null && !isSyncDone(sync);
     const hasErrors = sync != null && sync.errorCount > 0;
+    const pluginError = failedPlugins.get(pluginID);
 
     entries.push({
       pluginID,
@@ -214,7 +264,9 @@ export function useConnectionStatus(): ConnectionStatusSummary {
       isStarted: true,
       sync,
       isSyncing: syncing,
-      hasErrors,
+      hasErrors: hasErrors || pluginError != null,
+      pluginFailed: pluginError != null,
+      pluginError,
     });
   }
 
@@ -230,6 +282,7 @@ export function useConnectionStatus(): ConnectionStatusSummary {
   const syncArray = Array.from(syncs.values());
   const syncingEntries = entries.filter((e) => e.isSyncing);
   const errorEntries = entries.filter((e) => e.hasErrors);
+  const failedEntries = entries.filter((e) => e.pluginFailed);
 
   return {
     entries,
@@ -237,9 +290,11 @@ export function useConnectionStatus(): ConnectionStatusSummary {
     connectedCount: entries.length,
     syncingCount: syncingEntries.length,
     errorCount: errorEntries.length,
+    failedCount: failedEntries.length,
     hasSyncing: hasActiveSyncing(syncArray),
     aggregateProgress: computeAggregateProgress(syncArray),
     disconnect,
     retryWatch,
+    retryPlugin,
   };
 }

--- a/packages/omniviewdev-runtime/src/wailsjs/go/plugin/pluginManager.d.ts
+++ b/packages/omniviewdev-runtime/src/wailsjs/go/plugin/pluginManager.d.ts
@@ -44,6 +44,8 @@ export function LoadPlugin(arg1:string,arg2:plugin.LoadPluginOptions):Promise<ty
 
 export function ReloadPlugin(arg1:string):Promise<types.PluginInfo>;
 
+export function RetryFailedPlugin(arg1:string):Promise<types.PluginInfo>;
+
 export function Run(arg1:context.Context):Promise<void>;
 
 export function SearchPlugins(arg1:string,arg2:string,arg3:string):Promise<Array<registry.AvailablePlugin>>;

--- a/packages/omniviewdev-runtime/src/wailsjs/go/plugin/pluginManager.js
+++ b/packages/omniviewdev-runtime/src/wailsjs/go/plugin/pluginManager.js
@@ -74,6 +74,10 @@ export function ReloadPlugin(arg1) {
   return window['go']['plugin']['pluginManager']['ReloadPlugin'](arg1);
 }
 
+export function RetryFailedPlugin(arg1) {
+  return window['go']['plugin']['pluginManager']['RetryFailedPlugin'](arg1);
+}
+
 export function Run(arg1) {
   return window['go']['plugin']['pluginManager']['Run'](arg1);
 }

--- a/ui/components/displays/Footer/ConnectionStatusIndicator.tsx
+++ b/ui/components/displays/Footer/ConnectionStatusIndicator.tsx
@@ -109,8 +109,11 @@ function ConnectionRow({
   const { pluginID, connectionID, name, sync, isSyncing, hasErrors, pluginFailed } = entry;
 
   let dotColor = '#3fb950';
-  if (pluginFailed || hasErrors) dotColor = '#f85149';
-  else if (isSyncing) dotColor = '#58a6ff';
+  if (pluginFailed || hasErrors) {
+    dotColor = '#f85149';
+  } else if (isSyncing) {
+    dotColor = '#58a6ff';
+  }
 
   let statusText = 'Connected';
   if (pluginFailed) {
@@ -358,9 +361,13 @@ export default function ConnectionStatusIndicator() {
 
   if (failedCount > 0) {
     dotColor = '#f85149';
-    label = `${failedCount} failed`;
+    const nonFailedErrors = errorCount - failedCount;
+    label = nonFailedErrors > 0
+      ? `${failedCount} failed, ${nonFailedErrors} error${nonFailedErrors !== 1 ? 's' : ''}`
+      : `${failedCount} failed`;
   } else if (errorCount > 0) {
     dotColor = '#f85149';
+    label = `${errorCount} error${errorCount !== 1 ? 's' : ''}`;
   } else if (hasSyncing) {
     dotColor = '#58a6ff';
     label = `${syncingCount} syncing`;
@@ -424,9 +431,21 @@ export default function ConnectionStatusIndicator() {
         onClose={() => setAnchorEl(null)}
         grouped={grouped}
         connectedCount={connectedCount}
-        onDisconnect={(p, c) => disconnect(p, c).catch(() => {})}
-        onRetry={(p, c) => retryWatch(p, c).catch(() => {})}
-        onRetryPlugin={(p) => retryPlugin(p).catch(() => {})}
+        onDisconnect={(p, c) => {
+          void disconnect(p, c).catch((err: unknown) => {
+            console.error('Disconnect failed:', err);
+          });
+        }}
+        onRetry={(p, c) => {
+          void retryWatch(p, c).catch((err: unknown) => {
+            console.error('Retry watch failed:', err);
+          });
+        }}
+        onRetryPlugin={(p) => {
+          void retryPlugin(p).catch((err: unknown) => {
+            console.error('Retry plugin failed:', err);
+          });
+        }}
       />
     </>
   );

--- a/ui/components/displays/Footer/ConnectionStatusIndicator.tsx
+++ b/ui/components/displays/Footer/ConnectionStatusIndicator.tsx
@@ -99,26 +99,29 @@ function ConnectionRow({
   entry,
   onDisconnect,
   onRetry,
+  onRetryPlugin,
 }: {
   entry: ConnectionStatusEntry;
   onDisconnect: (pluginID: string, connectionID: string) => void;
   onRetry: (pluginID: string, connectionID: string) => void;
+  onRetryPlugin: (pluginID: string) => void;
 }) {
-  const { pluginID, connectionID, name, sync, isSyncing, hasErrors } = entry;
+  const { pluginID, connectionID, name, sync, isSyncing, hasErrors, pluginFailed } = entry;
 
-  const dotColor = hasErrors
-    ? '#f85149'
-    : isSyncing
-      ? '#58a6ff'
-      : '#3fb950';
+  let dotColor = '#3fb950';
+  if (pluginFailed || hasErrors) dotColor = '#f85149';
+  else if (isSyncing) dotColor = '#58a6ff';
 
-  const statusText = isSyncing && sync
-    ? `Syncing ${sync.doneCount}/${sync.watchedTotal} resources`
-    : hasErrors && sync
-      ? `${sync.errorCount} error${sync.errorCount !== 1 ? 's' : ''}`
-      : sync && sync.watchedTotal > 0
-        ? `Connected \u00B7 ${sync.watchedTotal} resources`
-        : 'Connected';
+  let statusText = 'Connected';
+  if (pluginFailed) {
+    statusText = 'Plugin crashed \u2014 recovery failed';
+  } else if (isSyncing && sync) {
+    statusText = `Syncing ${sync.doneCount}/${sync.watchedTotal} resources`;
+  } else if (hasErrors && sync) {
+    statusText = `${sync.errorCount} error${sync.errorCount !== 1 ? 's' : ''}`;
+  } else if (sync && sync.watchedTotal > 0) {
+    statusText = `Connected \u00B7 ${sync.watchedTotal} resources`;
+  }
 
   const percent = sync ? Math.round(sync.progress * 100) : 0;
 
@@ -205,14 +208,22 @@ function ConnectionRow({
 
       {/* Actions */}
       <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 0.25, mt: 0.25 }}>
-        {sync && (
+        {sync && !pluginFailed && (
           <PopoverAction
             icon={<LuInfo size={11} />}
             label="Details"
             onClick={handleDetails}
           />
         )}
-        {hasErrors && (
+        {pluginFailed && (
+          <PopoverAction
+            icon={<LuRefreshCw size={11} />}
+            label="Retry Plugin"
+            onClick={() => onRetryPlugin(pluginID)}
+            color="#58a6ff"
+          />
+        )}
+        {hasErrors && !pluginFailed && (
           <PopoverAction
             icon={<LuRefreshCw size={11} />}
             label="Retry"
@@ -241,6 +252,7 @@ function ConnectionStatusPopover({
   connectedCount,
   onDisconnect,
   onRetry,
+  onRetryPlugin,
 }: {
   anchorEl: HTMLElement | null;
   onClose: () => void;
@@ -248,6 +260,7 @@ function ConnectionStatusPopover({
   connectedCount: number;
   onDisconnect: (pluginID: string, connectionID: string) => void;
   onRetry: (pluginID: string, connectionID: string) => void;
+  onRetryPlugin: (pluginID: string) => void;
 }) {
   return (
     <Popover
@@ -306,6 +319,7 @@ function ConnectionStatusPopover({
                 entry={entry}
                 onDisconnect={onDisconnect}
                 onRetry={onRetry}
+                onRetryPlugin={onRetryPlugin}
               />
             ))}
           </React.Fragment>
@@ -325,10 +339,12 @@ export default function ConnectionStatusIndicator() {
     connectedCount,
     syncingCount,
     errorCount,
+    failedCount,
     hasSyncing,
     aggregateProgress,
     disconnect,
     retryWatch,
+    retryPlugin,
   } = useConnectionStatus();
 
   const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
@@ -337,10 +353,18 @@ export default function ConnectionStatusIndicator() {
   // Nothing to show
   if (connectedCount === 0) return null;
 
-  const dotColor = errorCount > 0 ? '#f85149' : hasSyncing ? '#58a6ff' : '#3fb950';
-  const label = hasSyncing
-    ? `${syncingCount} syncing`
-    : `${connectedCount} connected`;
+  let dotColor = '#3fb950';
+  let label = `${connectedCount} connected`;
+
+  if (failedCount > 0) {
+    dotColor = '#f85149';
+    label = `${failedCount} failed`;
+  } else if (errorCount > 0) {
+    dotColor = '#f85149';
+  } else if (hasSyncing) {
+    dotColor = '#58a6ff';
+    label = `${syncingCount} syncing`;
+  }
 
   const tooltipText = `${connectedCount} connection${connectedCount !== 1 ? 's' : ''} active`;
 
@@ -402,6 +426,7 @@ export default function ConnectionStatusIndicator() {
         connectedCount={connectedCount}
         onDisconnect={(p, c) => disconnect(p, c).catch(() => {})}
         onRetry={(p, c) => retryWatch(p, c).catch(() => {})}
+        onRetryPlugin={(p) => retryPlugin(p).catch(() => {})}
       />
     </>
   );


### PR DESCRIPTION
## Summary
- Backend: Added `ResetBudget()` to `HealthChecker` and call it from `ReloadPlugin` so manual retries get fresh crash recovery attempts instead of hitting an exhausted budget
- Frontend hook: `useConnectionStatus` now listens for `plugin/crash_recovery_failed` and `plugin/recovered` events, tracking failed plugins and exposing a `retryPlugin` action that calls `ReloadPlugin`
- Frontend UI: `ConnectionStatusIndicator` shows "Plugin crashed — recovery failed" status with red indicator and a "Retry Plugin" button; footer label shows failed count when plugins are down

## Verification
- `pnpm build` passes (includes tsc)
- `go build ./...` passes
- `go test ./backend/pkg/plugin/...` — all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added plugin crash recovery tracking with manual retry capability
  * Connection status indicator now displays plugin crash states with distinct visual feedback
  * New "Retry Plugin" action available in connection status interface for failed plugins

<!-- end of auto-generated comment: release notes by coderabbit.ai -->