### PR TITLE
fix: validate usePluginData return type against default value

### DIFF
--- a/packages/omniviewdev-runtime/src/hooks/data/usePluginData.ts
+++ b/packages/omniviewdev-runtime/src/hooks/data/usePluginData.ts
@@ -15,8 +15,9 @@ type UsePluginDataResult<T> = {
  * was stored but the caller expects an array).
  */
 function matchesShape<T>(value: unknown, defaultValue: T): value is T {
+  if (defaultValue === null) return value === null;
   if (Array.isArray(defaultValue)) return Array.isArray(value);
-  if (defaultValue !== null && typeof defaultValue === 'object') {
+  if (typeof defaultValue === 'object') {
     return typeof value === 'object' && value !== null && !Array.isArray(value);
   }
   return typeof value === typeof defaultValue;

--- a/packages/omniviewdev-runtime/src/hooks/data/usePluginData.ts
+++ b/packages/omniviewdev-runtime/src/hooks/data/usePluginData.ts
@@ -9,6 +9,20 @@ type UsePluginDataResult<T> = {
 };
 
 /**
+ * Check whether a value from the data store structurally matches the expected
+ * type indicated by the default value. This catches cases where the Go backend
+ * returns a JSON type that doesn't match the TypeScript generic (e.g. an object
+ * was stored but the caller expects an array).
+ */
+function matchesShape<T>(value: unknown, defaultValue: T): value is T {
+  if (Array.isArray(defaultValue)) return Array.isArray(value);
+  if (defaultValue !== null && typeof defaultValue === 'object') {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+  }
+  return typeof value === typeof defaultValue;
+}
+
+/**
  * Generic hook for reading/writing plugin data from the Plugin Data Store.
  * Uses React Query for caching and optimistic updates.
  */
@@ -26,6 +40,14 @@ export function usePluginData<T>(
     queryFn: async () => {
       const result = await Get(pluginID, key);
       if (result === null || result === undefined) {
+        return defaultValue;
+      }
+      if (!matchesShape(result, defaultValue)) {
+        console.warn(
+          `[usePluginData] stored value for "${key}" has unexpected type ` +
+          `(expected ${Array.isArray(defaultValue) ? 'array' : typeof defaultValue}, ` +
+          `got ${Array.isArray(result) ? 'array' : typeof result}). Using default.`,
+        );
         return defaultValue;
       }
       return result as T;


### PR DESCRIPTION
## Summary
- Adds runtime structural type validation to `usePluginData` before accepting stored values
- The Go backend returns `any` from the data store, and the `result as T` cast provides no runtime safety — when stored JSON has a different type than expected (e.g. object instead of array), callers crash with errors like `favorites.includes is not a function`
- New `matchesShape` helper checks array vs object vs primitive alignment against the default value; mismatches fall back to the default with a console warning

## Test plan
- [ ] Verify kubernetes plugin homecard loads without crashing when `cluster_favorites` key has corrupt/mismatched data in the store
- [ ] Verify normal read/write flow for arrays, objects, and primitives still works correctly
- [ ] Check console for warning messages when type mismatch occurs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced plugin data safety with runtime format validation. When retrieved data doesn't match the expected format, the system logs a warning and returns the default value, preventing potential data errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->