### PR TITLE
fix: keep log viewer pinned during drawer resize and minimize/reexpand

### DIFF
--- a/ui/providers/BottomDrawer/containers/LogViewer/index.tsx
+++ b/ui/providers/BottomDrawer/containers/LogViewer/index.tsx
@@ -188,10 +188,12 @@ const LogViewerContainer: React.FC<Props> = ({ sessionId, source, toolbarPrefix,
           // Restoring from minimized without follow: jump back to saved position
           isAutoScrolling.current = true;
           rowVirtualizer.scrollToIndex(savedFirstVisibleRef.current, { align: 'start' });
-          requestAnimationFrame(() => {
-            isAutoScrolling.current = false;
-          });
           savedFirstVisibleRef.current = null;
+          requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+              isAutoScrolling.current = false;
+            });
+          });
         }
       }
 

--- a/ui/providers/BottomDrawer/containers/LogViewer/index.tsx
+++ b/ui/providers/BottomDrawer/containers/LogViewer/index.tsx
@@ -163,10 +163,13 @@ const LogViewerContainer: React.FC<Props> = ({ sessionId, source, toolbarPrefix,
   followRef.current = follow;
   const filteredLineCountRef = useRef(filteredLineCount);
   filteredLineCountRef.current = filteredLineCount;
+  const filteredEntriesRef = useRef(filteredEntries);
+  filteredEntriesRef.current = filteredEntries;
 
   // Re-pin to bottom (or restore position) when the scroll container resizes.
   // This covers drawer drag-resize, minimize/re-expand, and fullscreen toggle.
-  const savedFirstVisibleRef = useRef<number | null>(null);
+  // We store a timestamp (not an index) so the anchor survives buffer eviction.
+  const savedVisibleTimestampRef = useRef<string | null>(null);
   const lastContainerHeightRef = useRef(0);
 
   React.useEffect(() => {
@@ -188,24 +191,33 @@ const LogViewerContainer: React.FC<Props> = ({ sessionId, source, toolbarPrefix,
               isAutoScrolling.current = false;
             });
           });
-        } else if (prevHeight === 0 && savedFirstVisibleRef.current !== null) {
-          // Restoring from minimized without follow: jump back to saved position
-          isAutoScrolling.current = true;
-          rowVirtualizer.scrollToIndex(savedFirstVisibleRef.current, { align: 'start' });
-          savedFirstVisibleRef.current = null;
-          requestAnimationFrame(() => {
+        } else if (prevHeight === 0 && savedVisibleTimestampRef.current !== null) {
+          // Restoring from minimized without follow: resolve saved timestamp to current index
+          const idx = findEntryIndexByTime(
+            filteredEntriesRef.current,
+            new Date(savedVisibleTimestampRef.current),
+          );
+          savedVisibleTimestampRef.current = null;
+          if (idx >= 0) {
+            isAutoScrolling.current = true;
+            rowVirtualizer.scrollToIndex(idx, { align: 'start' });
             requestAnimationFrame(() => {
-              isAutoScrolling.current = false;
+              requestAnimationFrame(() => {
+                isAutoScrolling.current = false;
+              });
             });
-          });
+          }
         }
       }
 
-      // Save the first visible index before the container collapses
+      // Save the first visible entry's timestamp before the container collapses
       if (prevHeight > 0 && newHeight === 0 && !followRef.current) {
         const range = rowVirtualizer.range;
         if (range) {
-          savedFirstVisibleRef.current = range.startIndex;
+          const entry = filteredEntriesRef.current[range.startIndex];
+          if (entry?.timestamp) {
+            savedVisibleTimestampRef.current = entry.timestamp;
+          }
         }
       }
 

--- a/ui/providers/BottomDrawer/containers/LogViewer/index.tsx
+++ b/ui/providers/BottomDrawer/containers/LogViewer/index.tsx
@@ -153,6 +153,63 @@ const LogViewerContainer: React.FC<Props> = ({ sessionId, source, toolbarPrefix,
     }
   }, [follow, filteredLineCount, version]);
 
+  // Keep refs in sync for use inside ResizeObserver (avoids re-subscribing)
+  const followRef = useRef(follow);
+  followRef.current = follow;
+  const filteredLineCountRef = useRef(filteredLineCount);
+  filteredLineCountRef.current = filteredLineCount;
+
+  // Re-pin to bottom (or restore position) when the scroll container resizes.
+  // This covers drawer drag-resize, minimize/re-expand, and fullscreen toggle.
+  const savedFirstVisibleRef = useRef<number | null>(null);
+  const lastContainerHeightRef = useRef(0);
+
+  React.useEffect(() => {
+    const el = parentRef.current;
+    if (!el) return;
+
+    const observer = new ResizeObserver((entries) => {
+      const rect = entries[0]?.contentRect;
+      if (!rect) return;
+      const newHeight = rect.height;
+      const prevHeight = lastContainerHeightRef.current;
+
+      if (newHeight > 0 && filteredLineCountRef.current > 0) {
+        if (followRef.current) {
+          // Follow mode: always pin to bottom
+          isAutoScrolling.current = true;
+          rowVirtualizer.scrollToIndex(filteredLineCountRef.current - 1, { align: 'end' });
+          requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+              isAutoScrolling.current = false;
+            });
+          });
+        } else if (prevHeight === 0 && savedFirstVisibleRef.current !== null) {
+          // Restoring from minimized without follow: jump back to saved position
+          isAutoScrolling.current = true;
+          rowVirtualizer.scrollToIndex(savedFirstVisibleRef.current, { align: 'start' });
+          requestAnimationFrame(() => {
+            isAutoScrolling.current = false;
+          });
+          savedFirstVisibleRef.current = null;
+        }
+      }
+
+      // Save the first visible index before the container collapses
+      if (prevHeight > 0 && newHeight === 0 && !followRef.current) {
+        const range = rowVirtualizer.range;
+        if (range) {
+          savedFirstVisibleRef.current = range.startIndex;
+        }
+      }
+
+      lastContainerHeightRef.current = newHeight;
+    });
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [rowVirtualizer]);
+
   // Detect scroll position to engage/disengage follow
   const handleScroll = useCallback(() => {
     if (!parentRef.current || isAutoScrolling.current) return;

--- a/ui/providers/BottomDrawer/containers/LogViewer/index.tsx
+++ b/ui/providers/BottomDrawer/containers/LogViewer/index.tsx
@@ -40,6 +40,11 @@ interface Props {
 
 const LogViewerContainer: React.FC<Props> = ({ sessionId, source, toolbarPrefix, toolbarActions }) => {
   const parentRef = useRef<HTMLDivElement>(null);
+  const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(null);
+  const scrollRefCallback = useCallback((node: HTMLDivElement | null) => {
+    parentRef.current = node;
+    setScrollElement(node);
+  }, []);
   const [showTimestamps, setShowTimestamps] = useState(false);
   const [showSources, setShowSources] = useState(false);
   const [showLineNumbers, setShowLineNumbers] = useState(false);
@@ -165,8 +170,7 @@ const LogViewerContainer: React.FC<Props> = ({ sessionId, source, toolbarPrefix,
   const lastContainerHeightRef = useRef(0);
 
   React.useEffect(() => {
-    const el = parentRef.current;
-    if (!el) return;
+    if (!scrollElement) return;
 
     const observer = new ResizeObserver((entries) => {
       const rect = entries[0]?.contentRect;
@@ -208,9 +212,9 @@ const LogViewerContainer: React.FC<Props> = ({ sessionId, source, toolbarPrefix,
       lastContainerHeightRef.current = newHeight;
     });
 
-    observer.observe(el);
+    observer.observe(scrollElement);
     return () => observer.disconnect();
-  }, [rowVirtualizer]);
+  }, [scrollElement, rowVirtualizer]);
 
   // Detect scroll position to engage/disengage follow
   const handleScroll = useCallback(() => {
@@ -659,7 +663,7 @@ const LogViewerContainer: React.FC<Props> = ({ sessionId, source, toolbarPrefix,
       ) : (
         /* Virtual log list */
         <Box
-          ref={parentRef}
+          ref={scrollRefCallback}
           onScroll={handleScroll}
           onKeyDown={handleLogKeyDown}
           onMouseDown={handleLogMouseDown}


### PR DESCRIPTION
## Summary
- Add a `ResizeObserver` on the log viewer scroll container to detect drawer size changes
- When follow mode is active, automatically re-pin to the last log entry during resize (drag, expand, fullscreen)
- When follow mode is off and the drawer is restored from minimized, save and restore the first visible line index so scroll position is preserved

## Tickets
- Bug: Resizing bottom bar doesn't keep logs pinned to bottom
- Bug: Log view resets to top after minimize/reexpand

## Verification
- `pnpm build` succeeds
- `pnpm lint` passes (no new errors — all errors are pre-existing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-scroll behavior in the log viewer when toggling follow mode so new entries stay in view as expected.
  * Restored and preserved precise scroll position when the log panel expands or collapses, returning you to the previously visible log line.
  * Smoother, more reliable scroll handling during panel resize to reduce jumps and maintain expected view position.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->