### PR TITLE
fix: render buffered output on terminal session attach

### DIFF
--- a/ui/providers/BottomDrawer/containers/Terminal.tsx
+++ b/ui/providers/BottomDrawer/containers/Terminal.tsx
@@ -309,7 +309,11 @@ export default function TerminalContainer({ sessionId, tab }: Props) {
       });
 
       try {
-        await ExecClient.AttachSession(sessionId);
+        const result = await ExecClient.AttachSession(sessionId);
+        if (result.buffer) {
+          const decoded = textDecoder.decode(Base64.toUint8Array(result.buffer));
+          terminal.write(decoded);
+        }
       } catch (e) {
         log.error(new Error(parseAppError(e).detail), { event: 'attach_session', sessionId });
       }


### PR DESCRIPTION
## Summary
- `AttachSession` returns a buffer containing output that arrived before the UI attached (e.g. the shell prompt), but the return value was ignored
- The initial prompt never appeared — users had to type a command before seeing any output
- Now writes the buffer contents to the xterm terminal after attaching

Companion to omniviewdev/plugin-sdk#8 (merged as v0.5.1) which fixed sessions being destroyed immediately after creation.

## Test plan
- [ ] Exec into a pod — initial shell prompt should appear immediately without needing to type first

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal sessions now display initial output immediately upon attachment, improving responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->