### PR TITLE
fix: destructure AttachSession tuple for buffer rendering

### DIFF
--- a/ui/providers/BottomDrawer/containers/Terminal.tsx
+++ b/ui/providers/BottomDrawer/containers/Terminal.tsx
@@ -309,9 +309,9 @@ export default function TerminalContainer({ sessionId, tab }: Props) {
       });
 
       try {
-        const result = await ExecClient.AttachSession(sessionId);
-        if (result.buffer) {
-          const decoded = textDecoder.decode(Base64.toUint8Array(result.buffer));
+        const [, buffer] = await ExecClient.AttachSession(sessionId);
+        if (buffer) {
+          const decoded = textDecoder.decode(Base64.toUint8Array(buffer));
           terminal.write(decoded);
         }
       } catch (e) {


### PR DESCRIPTION
## Summary
- Follow-up to #51 — `AttachSession` returns a Wails v3 tuple `[Session, buffer]`, not an object
- `result.buffer` was `undefined` on a tuple; destructure as `[, buffer]` to get the second element
- Also requires plugin-sdk v0.5.2 which fixes the race between `handleStream` and `AttachSession` that could orphan the initial prompt data

## Test plan
- [ ] Exec into a pod — initial shell prompt should appear without typing first

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**No user-visible changes.** This release contains internal code optimizations to improve maintainability. Terminal functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->