### PR TITLE
fix: swap rows/cols in exec resize adapter

### DIFF
--- a/backend/pkg/plugin/exec/adapter_v1.go
+++ b/backend/pkg/plugin/exec/adapter_v1.go
@@ -50,7 +50,7 @@ func (a *AdapterV1) CloseSession(ctx *types.PluginContext, sessionID string) err
 }
 
 func (a *AdapterV1) ResizeSession(ctx *types.PluginContext, sessionID string, cols, rows int32) error {
-	return a.inner.ResizeSession(ctx, sessionID, cols, rows)
+	return a.inner.ResizeSession(ctx, sessionID, rows, cols)
 }
 
 func (a *AdapterV1) Stream(ctx context.Context, in chan exec.StreamInput) (chan exec.StreamOutput, error) {


### PR DESCRIPTION
## Summary
- `AdapterV1.ResizeSession` receives `(cols, rows)` but passes them straight through to `PluginClient.ResizeSession` which expects `(rows, cols)`
- This caused the remote terminal to receive swapped dimensions (e.g. 236×36 instead of 36×236)
- Result: terminal output corruption — lines wrapping/scrolling at wrong positions

Verified via `stty size` in exec session showing `236 36` (rows cols) instead of `36 236`.

## Test plan
- [ ] Exec into a pod, run `stty size` — should match the UI terminal dimensions
- [ ] Run `ls -lah /` — output should render without corruption

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with terminal session resizing where arguments were being passed in the incorrect order, ensuring proper display dimensions are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->